### PR TITLE
gitignore; rosinstall verification/fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,52 @@
+*.py[cod]
+
+# C extensions
+*.so
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+lib
+lib64
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+.tox
+nosetests.xml
+
+# Translations
+*.mo
+
+# Mr Developer
+.mr.developer.cfg
+.project
+.cproject
+cmake_install.cmake
+.pydevproject
+*.swp
+CATKIN_IGNORE
+catkin
+catkin_generated
+devel
+
+cpp
+docs
+msg_gen
+srv_gen
+*.smoketest
+*.cfgc
+*_msgs/src/
+*/src/**/cfg
+*/*/src/**/*

--- a/baxter_simulator.rosinstall
+++ b/baxter_simulator.rosinstall
@@ -40,5 +40,5 @@
     version: release-0.7.0
 - git:
     local-name: baxter
-    uri: git@github.com:RethinkRobotics/sdk-examples.git
+    uri: git@github.com:RethinkRobotics/baxter.git
     version: release-0.7.0


### PR DESCRIPTION
Verifying package.xml and rosinstall and version numbers for 0.7.0
release and the rename and breakout of the Baxter SDK repositories,
especially 'sdk-examples' -> 'baxter'
