### PR TITLE
SEAJointState message dependency issue fix

### DIFF
--- a/baxter_sim_kinematics/CMakeLists.txt
+++ b/baxter_sim_kinematics/CMakeLists.txt
@@ -35,6 +35,7 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
 add_executable(kinematics src/position_kinematics.cpp)
 target_link_libraries(kinematics ${catkin_LIBRARIES} ${PROJECT_NAME})
 
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
  add_dependencies(kinematics
   ${catkin_EXPORTED_TARGETS}
   baxter_core_msgs_gencpp


### PR DESCRIPTION
There was a dependency issue in baxter_sim_kinematics that was causing the catkin_make to fail. Fixed this by adding the dependency in the CMakeLists.txt of baxter_sim_kinematics package. Also the rosinstall file was updated to pull the release branches
