### PR TITLE
Update rosinstall to match HTTPS style baxter_sdk

### DIFF
--- a/baxter_simulator.rosinstall
+++ b/baxter_simulator.rosinstall
@@ -4,45 +4,45 @@
     version: release-0.8.0
 - git:
     local-name: gazebo_ros_pkgs
-    uri: git@github.com:RethinkRobotics/gazebo_ros_pkgs.git
+    uri: https://github.com/RethinkRobotics/gazebo_ros_pkgs.git
     version: release-0.8.0
 - git:
-    local-name: ros_controllers
-    uri: git@github.com:RethinkRobotics/ros_controllers.git
-    version: hydro-devel
-- git:
     local-name: ros_control
-    uri: git@github.com:RethinkRobotics/ros_control.git
+    uri: https://github.com/RethinkRobotics/ros_control.git
     version: release-0.8.0
 - git:
     local-name: control_toolbox
-    uri: git@github.com:RethinkRobotics/control_toolbox.git
+    uri: https://github.com/RethinkRobotics/control_toolbox.git
     version: hydro-devel
 - git:
     local-name: realtime_tools
-    uri: git@github.com:RethinkRobotics/realtime_tools.git
+    uri: https://github.com/RethinkRobotics/realtime_tools.git
     version: hydro-devel
 - git:
-    local-name: baxter_interface
-    uri: git@github.com:RethinkRobotics/baxter_interface.git
+    local-name: ros_controllers
+    uri: https://github.com/RethinkRobotics/ros_controllers.git
+    version: hydro-devel
+- git:
+    local-name: xacro
+    uri: https://github.com/RethinkRobotics/xacro.git
+    version: hydro-devel
+- git:
+    local-name: baxter
+    uri: https://github.com/RethinkRobotics/baxter.git
     version: release-1.0.0
 - git:
-    local-name: baxter_examples
-    uri: git@github.com:RethinkRobotics/baxter_examples.git
+    local-name: baxter_interface
+    uri: https://github.com/RethinkRobotics/baxter_interface.git
     version: release-1.0.0
 - git:
     local-name: baxter_tools
-    uri: git@github.com:RethinkRobotics/baxter_tools.git
+    uri: https://github.com/RethinkRobotics/baxter_tools.git
     version: release-1.0.0
 - git:
     local-name: baxter_common
-    uri: git@github.com:RethinkRobotics/baxter_common.git
+    uri: https://github.com/RethinkRobotics/baxter_common.git
     version: release-1.0.0
 - git:
-    local-name: baxter
-    uri: git@github.com:RethinkRobotics/baxter.git
+    local-name: baxter_examples
+    uri: https://github.com/RethinkRobotics/baxter_examples.git
     version: release-1.0.0
-- git:
-    local-name: xacro
-    uri: git@github.com:RethinkRobotics/xacro.git
-    version: hydro-devel


### PR DESCRIPTION
Simulator rosinstall file is updated to HTTPS links to match the
switch-over to HTTPS URI's in the baxter_sdk.rosinstall (baxter
repo). This way, local repositories will not be wiped out when
installing the simulator.
- Note that instructions for updating existing SSH-style uri's
  (git@github.com:____) will still need to be written / figured-
  -out, as the switch over (or upgrade from 0.7.0 ros_ws) will
  still wipe out local repos.
