### PR TITLE
[development] endpoint_state topics missing time stamp

### DIFF
--- a/baxter_sim_kinematics/src/position_kinematics.cpp
+++ b/baxter_sim_kinematics/src/position_kinematics.cpp
@@ -118,6 +118,9 @@ void position_kinematics::FKCallback(const sensor_msgs::JointState msg) {
   //Copy the current Joint positions and names of the appropriate side to the configuration
   endpoint.pose = position_kinematics::FKCalc(joint).pose;
 
+  //Fill out timestamp for endpoint
+  endpoint.header.stamp = msg.header.stamp;
+
   //Publish the PoseStamp of the end effector
   end_pointstate_pub.publish(endpoint);
 }


### PR DESCRIPTION
This hurts compatibility with tools such as rosbag and rqt_plot. The real Baxter does not have this issue.
