### PR TITLE
Fixed invalid quaternion for static tf publisher between world and base.

### DIFF
--- a/baxter_gazebo/launch/baxter_world.launch
+++ b/baxter_gazebo/launch/baxter_world.launch
@@ -26,7 +26,7 @@
   <param name="rethink/software_version" value="1.1.1" />
 
   <!-- Publish a static transform between the world and the base of the robot -->
-  <node pkg="tf2_ros" type="static_transform_publisher" name="base_to_world" args="0 0 0 0 0 0 0 world base" />
+  <node pkg="tf2_ros" type="static_transform_publisher" name="base_to_world" args="0 0 0 0 0 0 1 world base" />
 
   <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
    <node name="urdf_spawner" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"


### PR DESCRIPTION
The static tf publisher between world and base for baxter in simulation had an invalid quaterion breaking the tf tree under ros indigo.

   $  rosrun tf tf_echo /world /base
    At time 0.000
    - Translation: [0.000, 0.000, 0.000]
    - Rotation: in Quaternion [-nan, -nan, -nan, -nan]
                in RPY (radian) [-nan, nan, -nan]
                in RPY (degree) [-nan, nan, -nan]
    At time 0.000
