### PR TITLE
Fixed use of non-standard C++ syntax for variable length arrays.

### DIFF
--- a/baxter_sim_controllers/src/baxter_effort_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_effort_controller.cpp
@@ -87,7 +87,9 @@ bool BaxterEffortController::init(
     }
 	
     // Get joint names from the parameter server
-     std::string joint_name[n_joints_];
+    // FIX: Initialising arrays with a variable for the length is a GCC extension and not standard C++
+    //     std::string joint_name[n_joints_];
+    std::vector<std::string> joint_name = std::vector<std::string>(n_joints_);
     // Get joint controller name
     std::string joint_controller_name = joint_it->first;
    


### PR DESCRIPTION
Baxter simulator code failed to compile under Clang because of the use of a GCC extension that allows an array to be initialised with a variable length. Used std::vector instead.
