### PR TITLE
[baxter_sim_hardware] modify default value of electric gripper false

### DIFF
--- a/baxter_sim_hardware/launch/baxter_sdk_control.launch
+++ b/baxter_sim_hardware/launch/baxter_sdk_control.launch
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <launch>
 
-  <arg name="left_electric_gripper" default="true"/>
-  <arg name="right_electric_gripper" default="true"/>
+  <arg name="left_electric_gripper" default="false"/>
+  <arg name="right_electric_gripper" default="false"/>
 
   <!-- baxter_sim_kinematics launch file to do the Forward/Inverse Kinematics -->
   <include file="$(find baxter_sim_kinematics)/launch/baxter_sim_kinematics.launch" />


### PR DESCRIPTION
electric gripper value should be standardized to false, according to baxter_sim_kinematics and version 0.9 or older
https://github.com/RethinkRobotics/baxter_simulator/blob/master/baxter_sim_kinematics/launch/baxter_sim_kinematics.launch#L5-L6
