### PR TITLE
[baxter_sim_kinematics] load electric gripper description by default

### DIFF
--- a/baxter_sim_kinematics/launch/baxter_sim_kinematics.launch
+++ b/baxter_sim_kinematics/launch/baxter_sim_kinematics.launch
@@ -3,8 +3,8 @@
 
   <!-- Load the URDF into the ROS Parameter Server -->
   <arg name="load_robot_description" default="false"/>
-  <arg name="right_electric_gripper" default="false"/>
-  <arg name="left_electric_gripper" default="false"/>
+  <arg name="right_electric_gripper" default="true"/>
+  <arg name="left_electric_gripper" default="true"/>
 
   <!-- Load universal robotic description format (URDF) -->
   <param if="$(arg load_robot_description)" name="robot_description"


### PR DESCRIPTION
Related to #86

electric gripper should be loaded to baxter_simulator by default
