### PR TITLE
Ran clang-format recursively on baxter_simulator

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,66 @@
+---
+BasedOnStyle:  Google
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: false
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+ColumnLimit:    120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 90
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: false
+Standard:        Auto
+IndentWidth:     2
+TabWidth:        2
+UseTab:          Never
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles:  false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+SortIncludes: false
+SpaceAfterCStyleCast: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+}
+...

--- a/baxter_gazebo/src/baxter_gazebo_ros_control_plugin.cpp
+++ b/baxter_gazebo/src/baxter_gazebo_ros_control_plugin.cpp
@@ -50,11 +50,11 @@
 #include <baxter_core_msgs/HeadPanCommand.h>
 #include <baxter_core_msgs/EndEffectorCommand.h>
 
-namespace baxter_gazebo_plugin {
-
-class BaxterGazeboRosControlPlugin :
-    public gazebo_ros_control::GazeboRosControlPlugin {
- private:
+namespace baxter_gazebo_plugin
+{
+class BaxterGazeboRosControlPlugin : public gazebo_ros_control::GazeboRosControlPlugin
+{
+private:
   ros::Subscriber left_command_mode_sub_;
   ros::Subscriber right_command_mode_sub_;
   ros::Subscriber robot_state_sub_;
@@ -69,42 +69,39 @@ class BaxterGazeboRosControlPlugin :
   baxter_core_msgs::AssemblyState assembly_state_;
 
   // use this as flag to indicate current mode
-  baxter_core_msgs::JointCommand right_command_mode_,left_command_mode_;
+  baxter_core_msgs::JointCommand right_command_mode_, left_command_mode_;
 
   boost::mutex mtx_;  // mutex for re-entrent calls to modeCommandCallback
-  bool enable_cmd, is_disabled, head_is_started, left_gripper_is_started, right_gripper_is_started;  // enabled tracks the current status of the robot that is being published & is_disabled keeps track of the action taken
+  bool enable_cmd, is_disabled, head_is_started, left_gripper_is_started,
+      right_gripper_is_started;  // enabled tracks the current status of the robot that is being published & is_disabled
+                                 // keeps track of the action taken
 
- public:
-
-  void Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf) {
+public:
+  void Load(gazebo::physics::ModelPtr parent, sdf::ElementPtr sdf)
+  {
     // Load parent class first
     GazeboRosControlPlugin::Load(parent, sdf);
 
     // Baxter customizations:
-    ROS_INFO_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                          "Loading Baxter specific simulation components");
+    ROS_INFO_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Loading Baxter specific simulation components");
 
     // Subscribe to a topic that switches' Baxter's msgs
-    left_command_mode_sub_ =
-        model_nh_.subscribe < baxter_core_msgs::JointCommand
-            > ("/robot/limb/left/joint_command", 1, &BaxterGazeboRosControlPlugin::leftModeCommandCallback, this);
-    right_command_mode_sub_ =
-        model_nh_.subscribe < baxter_core_msgs::JointCommand
-            > ("/robot/limb/right/joint_command", 1, &BaxterGazeboRosControlPlugin::rightModeCommandCallback, this);
-    head_state_sub =
-        model_nh_.subscribe < baxter_core_msgs::HeadPanCommand
-            > ("/robot/head/command_head_pan", 1, &BaxterGazeboRosControlPlugin::headCommandCallback, this);
-    left_gripper_state_sub =
-        model_nh_.subscribe < baxter_core_msgs::EndEffectorCommand
-            > ("/robot/end_effector/left_gripper/command", 1, &BaxterGazeboRosControlPlugin::leftEndEffectorCommandCallback, this);
-    right_gripper_state_sub =
-        model_nh_.subscribe < baxter_core_msgs::EndEffectorCommand
-            > ("/robot/end_effector/right_gripper/command", 1, &BaxterGazeboRosControlPlugin::rightEndEffectorCommandCallback, this);
+    left_command_mode_sub_ = model_nh_.subscribe<baxter_core_msgs::JointCommand>(
+        "/robot/limb/left/joint_command", 1, &BaxterGazeboRosControlPlugin::leftModeCommandCallback, this);
+    right_command_mode_sub_ = model_nh_.subscribe<baxter_core_msgs::JointCommand>(
+        "/robot/limb/right/joint_command", 1, &BaxterGazeboRosControlPlugin::rightModeCommandCallback, this);
+    head_state_sub = model_nh_.subscribe<baxter_core_msgs::HeadPanCommand>(
+        "/robot/head/command_head_pan", 1, &BaxterGazeboRosControlPlugin::headCommandCallback, this);
+    left_gripper_state_sub = model_nh_.subscribe<baxter_core_msgs::EndEffectorCommand>(
+        "/robot/end_effector/left_gripper/command", 1, &BaxterGazeboRosControlPlugin::leftEndEffectorCommandCallback,
+        this);
+    right_gripper_state_sub = model_nh_.subscribe<baxter_core_msgs::EndEffectorCommand>(
+        "/robot/end_effector/right_gripper/command", 1, &BaxterGazeboRosControlPlugin::rightEndEffectorCommandCallback,
+        this);
 
-    //Subscribe to the topic that publishes the robot's state
-    robot_state_sub_ =
-        model_nh_.subscribe < baxter_core_msgs::AssemblyState
-            > ("/robot/state", 1, &BaxterGazeboRosControlPlugin::enableCommandCallback, this);
+    // Subscribe to the topic that publishes the robot's state
+    robot_state_sub_ = model_nh_.subscribe<baxter_core_msgs::AssemblyState>(
+        "/robot/state", 1, &BaxterGazeboRosControlPlugin::enableCommandCallback, this);
 
     enable_cmd = false;
     is_disabled = false;
@@ -115,13 +112,15 @@ class BaxterGazeboRosControlPlugin :
     right_gripper_is_started = false;
   }
 
-  void enableCommandCallback(const baxter_core_msgs::AssemblyState msg) {
+  void enableCommandCallback(const baxter_core_msgs::AssemblyState msg)
+  {
     enable_cmd = msg.enabled;
-    std::vector < std::string > start_controllers;
-    std::vector < std::string > stop_controllers;
+    std::vector<std::string> start_controllers;
+    std::vector<std::string> stop_controllers;
 
     // Check if we got disable signal and if the controllers are not already disabled
-    if (!enable_cmd && !is_disabled) {
+    if (!enable_cmd && !is_disabled)
+    {
       stop_controllers.push_back("left_joint_effort_controller");
       stop_controllers.push_back("left_joint_velocity_controller");
       stop_controllers.push_back("left_joint_position_controller");
@@ -132,18 +131,19 @@ class BaxterGazeboRosControlPlugin :
       stop_controllers.push_back("left_gripper_controller");
       stop_controllers.push_back("right_gripper_controller");
 
-      if (!controller_manager_->switchController(
-          start_controllers, stop_controllers,
-          controller_manager_msgs::SwitchController::Request::BEST_EFFORT)) {
-        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                               "Failed to switch controllers");
-      } else {
-        //Resetting the command modes to the initial configuration
-	ROS_INFO("Robot is disabled");
-	ROS_INFO("Gravity compensation was turned off");
+      if (!controller_manager_->switchController(start_controllers, stop_controllers,
+                                                 controller_manager_msgs::SwitchController::Request::BEST_EFFORT))
+      {
+        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Failed to switch controllers");
+      }
+      else
+      {
+        // Resetting the command modes to the initial configuration
+        ROS_INFO("Robot is disabled");
+        ROS_INFO("Gravity compensation was turned off");
         right_command_mode_.mode = -1;
         left_command_mode_.mode = -1;
-        head_is_started=false;
+        head_is_started = false;
         left_gripper_is_started = false;
         right_gripper_is_started = false;
         is_disabled = true;
@@ -151,151 +151,159 @@ class BaxterGazeboRosControlPlugin :
     }
   }
 
-  void leftEndEffectorCommandCallback(
-      const baxter_core_msgs::EndEffectorCommand msg) {
-    if (!left_gripper_is_started && enable_cmd){
-      std::vector < std::string > start_controllers;
-      std::vector < std::string > stop_controllers;
+  void leftEndEffectorCommandCallback(const baxter_core_msgs::EndEffectorCommand msg)
+  {
+    if (!left_gripper_is_started && enable_cmd)
+    {
+      std::vector<std::string> start_controllers;
+      std::vector<std::string> stop_controllers;
 
       start_controllers.push_back("left_gripper_controller");
-      if (!controller_manager_->switchController(
-          start_controllers, stop_controllers,
-          controller_manager_msgs::SwitchController::Request::STRICT)) {
-        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                               "Failed to switch controllers");
+      if (!controller_manager_->switchController(start_controllers, stop_controllers,
+                                                 controller_manager_msgs::SwitchController::Request::STRICT))
+      {
+        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Failed to switch controllers");
       }
-      else {
+      else
+      {
         ROS_INFO("Robot is enabled");
         ROS_INFO("Left Grippercontroller was successfully started");
         ROS_INFO("Gravity compensation was turned on");
-        left_gripper_is_started=true;
-	      is_disabled=false;
+        left_gripper_is_started = true;
+        is_disabled = false;
       }
     }
     else
       return;
   }
-  void rightEndEffectorCommandCallback(
-      const baxter_core_msgs::EndEffectorCommand msg) {
-    if (!right_gripper_is_started && enable_cmd){
-      std::vector < std::string > start_controllers;
-      std::vector < std::string > stop_controllers;
+  void rightEndEffectorCommandCallback(const baxter_core_msgs::EndEffectorCommand msg)
+  {
+    if (!right_gripper_is_started && enable_cmd)
+    {
+      std::vector<std::string> start_controllers;
+      std::vector<std::string> stop_controllers;
 
       start_controllers.push_back("right_gripper_controller");
-      if (!controller_manager_->switchController(
-          start_controllers, stop_controllers,
-          controller_manager_msgs::SwitchController::Request::STRICT)) {
-        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                               "Failed to switch controllers");
+      if (!controller_manager_->switchController(start_controllers, stop_controllers,
+                                                 controller_manager_msgs::SwitchController::Request::STRICT))
+      {
+        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Failed to switch controllers");
       }
-      else {
+      else
+      {
         ROS_INFO("Robot is enabled");
         ROS_INFO("Right Grippercontroller was successfully started");
         ROS_INFO("Gravity compensation was turned on");
-        right_gripper_is_started=true;
-	      is_disabled=false;
+        right_gripper_is_started = true;
+        is_disabled = false;
       }
     }
     else
       return;
   }
-  void headCommandCallback(
-      const baxter_core_msgs::HeadPanCommand msg) {
-    if (!head_is_started && enable_cmd){
-      std::vector < std::string > start_controllers;
-      std::vector < std::string > stop_controllers;
+  void headCommandCallback(const baxter_core_msgs::HeadPanCommand msg)
+  {
+    if (!head_is_started && enable_cmd)
+    {
+      std::vector<std::string> start_controllers;
+      std::vector<std::string> stop_controllers;
 
       start_controllers.push_back("head_position_controller");
-      if (!controller_manager_->switchController(
-          start_controllers, stop_controllers,
-          controller_manager_msgs::SwitchController::Request::STRICT)) {
-        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                               "Failed to switch controllers");
+      if (!controller_manager_->switchController(start_controllers, stop_controllers,
+                                                 controller_manager_msgs::SwitchController::Request::STRICT))
+      {
+        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Failed to switch controllers");
       }
-      else {
+      else
+      {
         ROS_INFO("Robot is enabled");
         ROS_INFO("Head controller was successfully started");
         ROS_INFO("Gravity compensation was turned on");
-        head_is_started=true;
-	      is_disabled=false;
+        head_is_started = true;
+        is_disabled = false;
       }
     }
     else
       return;
   }
-  void leftModeCommandCallback(
-      const baxter_core_msgs::JointCommandConstPtr& msg) {
-
-    //Check if we already received this command for this arm and bug out if so
-    if (left_command_mode_.mode == msg->mode) {
+  void leftModeCommandCallback(const baxter_core_msgs::JointCommandConstPtr& msg)
+  {
+    // Check if we already received this command for this arm and bug out if so
+    if (left_command_mode_.mode == msg->mode)
+    {
       return;
-    } else if (enable_cmd) {
-      left_command_mode_.mode = msg->mode;  //cache last mode
+    }
+    else if (enable_cmd)
+    {
+      left_command_mode_.mode = msg->mode;  // cache last mode
       modeCommandCallback(msg, "left");
-    } else {
-      ROS_WARN_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                            "Enable the robot");
+    }
+    else
+    {
+      ROS_WARN_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Enable the robot");
       return;
     }
   }
 
-  void rightModeCommandCallback(
-      const baxter_core_msgs::JointCommandConstPtr& msg) {
-
-    //Check if we already received this command for this arm and bug out if so
-    if (right_command_mode_.mode == msg->mode) {
+  void rightModeCommandCallback(const baxter_core_msgs::JointCommandConstPtr& msg)
+  {
+    // Check if we already received this command for this arm and bug out if so
+    if (right_command_mode_.mode == msg->mode)
+    {
       return;
-    } else if (enable_cmd) {
-      right_command_mode_.mode = msg->mode;  //cache last mode
+    }
+    else if (enable_cmd)
+    {
+      right_command_mode_.mode = msg->mode;  // cache last mode
       modeCommandCallback(msg, "right");
-    } else {
-      ROS_WARN_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                            "Enable the robot");
+    }
+    else
+    {
+      ROS_WARN_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Enable the robot");
       return;
     }
   }
 
-  void modeCommandCallback(const baxter_core_msgs::JointCommandConstPtr& msg,
-                           const std::string& side) {
-    ROS_DEBUG_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                           "Switching command mode for side " << side);
+  void modeCommandCallback(const baxter_core_msgs::JointCommandConstPtr& msg, const std::string& side)
+  {
+    ROS_DEBUG_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Switching command mode for side " << side);
 
-    //lock out other thread(s) which are getting called back via ros.
-    boost::lock_guard < boost::mutex > guard(mtx_);
+    // lock out other thread(s) which are getting called back via ros.
+    boost::lock_guard<boost::mutex> guard(mtx_);
 
-    std::vector < std::string > start_controllers;
-    std::vector < std::string > stop_controllers;
-    std::string start,stop;
+    std::vector<std::string> start_controllers;
+    std::vector<std::string> stop_controllers;
+    std::string start, stop;
 
-    switch (msg->mode) {
+    switch (msg->mode)
+    {
       case baxter_core_msgs::JointCommand::POSITION_MODE:
       case baxter_core_msgs::JointCommand::RAW_POSITION_MODE:
         start_controllers.push_back(side + "_joint_position_controller");
         stop_controllers.push_back(side + "_joint_velocity_controller");
         stop_controllers.push_back(side + "_joint_effort_controller");
-        start=side+"_joint_position_controller";
-	stop=side+"_joint_velocity_controller and "+side+"_joint_effort_controller";
+        start = side + "_joint_position_controller";
+        stop = side + "_joint_velocity_controller and " + side + "_joint_effort_controller";
         break;
       case baxter_core_msgs::JointCommand::VELOCITY_MODE:
         start_controllers.push_back(side + "_joint_velocity_controller");
         stop_controllers.push_back(side + "_joint_position_controller");
         stop_controllers.push_back(side + "_joint_effort_controller");
-        start=side+"_joint_velocity_controller";
-	stop=side+"_joint_position_controller and "+side+"_joint_effort_controller";
+        start = side + "_joint_velocity_controller";
+        stop = side + "_joint_position_controller and " + side + "_joint_effort_controller";
         break;
       case baxter_core_msgs::JointCommand::TORQUE_MODE:
         start_controllers.push_back(side + "_joint_effort_controller");
         stop_controllers.push_back(side + "_joint_position_controller");
         stop_controllers.push_back(side + "_joint_velocity_controller");
-        start=side+"_joint_position_controller";
-	stop=side+"_joint_velocity_controller and "+side+"_joint_velocity_controller";
+        start = side + "_joint_position_controller";
+        stop = side + "_joint_velocity_controller and " + side + "_joint_velocity_controller";
         break;
       default:
-        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                               "Unknown command mode " << msg->mode);
+        ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Unknown command mode " << msg->mode);
         return;
     }
-    //Checks if we have already disabled the controllers
+    // Checks if we have already disabled the controllers
     /** \brief Switch multiple controllers simultaneously.
      *
      * \param start_controllers A vector of controller names to be started
@@ -306,22 +314,21 @@ class BaxterGazeboRosControlPlugin :
      * or \c STRICT.  \c BEST_EFFORT means that \ref switchController can still
      * succeed if a non-existant controller is requested to be stopped or started.
      */
-    if (!controller_manager_->switchController(
-        start_controllers, stop_controllers,
-        controller_manager_msgs::SwitchController::Request::BEST_EFFORT)) {
-      ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin",
-                             "Failed to switch controllers");
+    if (!controller_manager_->switchController(start_controllers, stop_controllers,
+                                               controller_manager_msgs::SwitchController::Request::BEST_EFFORT))
+    {
+      ROS_ERROR_STREAM_NAMED("baxter_gazebo_ros_control_plugin", "Failed to switch controllers");
     }
-    else {
-       is_disabled=false;
-       ROS_INFO("Robot is enabled");
-       ROS_INFO_STREAM(start<<" was started and "<<stop<<" were stopped succesfully");
-       ROS_INFO("Gravity compensation was turned on");
+    else
+    {
+      is_disabled = false;
+      ROS_INFO("Robot is enabled");
+      ROS_INFO_STREAM(start << " was started and " << stop << " were stopped succesfully");
+      ROS_INFO("Gravity compensation was turned on");
     }
   }
-
 };
 
 // Register this plugin with the simulator
-GZ_REGISTER_MODEL_PLUGIN (BaxterGazeboRosControlPlugin);
+GZ_REGISTER_MODEL_PLUGIN(BaxterGazeboRosControlPlugin);
 }  // namespace

--- a/baxter_sim_controllers/include/baxter_sim_controllers/baxter_effort_controller.h
+++ b/baxter_sim_controllers/include/baxter_sim_controllers/baxter_effort_controller.h
@@ -45,27 +45,25 @@
 #include <controller_interface/controller.h>
 #include <realtime_tools/realtime_buffer.h>
 
-#include <baxter_core_msgs/JointCommand.h> // the input command
+#include <baxter_core_msgs/JointCommand.h>  // the input command
 
-#include <effort_controllers/joint_effort_controller.h> // used for controlling individual joints
+#include <effort_controllers/joint_effort_controller.h>  // used for controlling individual joints
 
-namespace baxter_sim_controllers {
-
-class BaxterEffortController : public controller_interface::Controller<
-    hardware_interface::EffortJointInterface> {
-
- public:
+namespace baxter_sim_controllers
+{
+class BaxterEffortController : public controller_interface::Controller<hardware_interface::EffortJointInterface>
+{
+public:
   BaxterEffortController();
   ~BaxterEffortController();
 
-  bool init(hardware_interface::EffortJointInterface *robot,
-            ros::NodeHandle &n);
+  bool init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& n);
   void starting(const ros::Time& time);
   void stopping(const ros::Time& time);
   void update(const ros::Time& time, const ros::Duration& period);
   void updateCommands();
 
- private:
+private:
   ros::NodeHandle nh_;
   size_t n_joints_;
   std::string topic_name;
@@ -87,7 +85,6 @@ class BaxterEffortController : public controller_interface::Controller<
 
   // Create an effort-based joint effort controller for every joint
   std::vector<boost::shared_ptr<effort_controllers::JointEffortController> > effort_controllers_;
-
 };
 
 }  // namespace

--- a/baxter_sim_controllers/include/baxter_sim_controllers/baxter_gripper_controller.h
+++ b/baxter_sim_controllers/include/baxter_sim_controllers/baxter_gripper_controller.h
@@ -27,7 +27,6 @@
  # POSSIBILITY OF SUCH DAMAGE.
  *********************************************************************/
 
-
 #ifndef BAXTER_GRIPPER_CONTROLLER_H_
 #define BAXTER_GRIPPER_CONTROLLER_H_
 
@@ -42,56 +41,52 @@
 #include <realtime_tools/realtime_buffer.h>
 
 #include <baxter_core_msgs/EndEffectorCommand.h>
-#include <effort_controllers/joint_position_controller.h> // used for controlling individual joints
-
+#include <effort_controllers/joint_position_controller.h>  // used for controlling individual joints
 
 namespace baxter_sim_controllers
 {
-  class BaxterGripperController: public controller_interface::Controller<hardware_interface::EffortJointInterface>
-  {
+class BaxterGripperController : public controller_interface::Controller<hardware_interface::EffortJointInterface>
+{
+public:
+  BaxterGripperController();
+  ~BaxterGripperController();
 
-  public:
-    BaxterGripperController();
-    ~BaxterGripperController();
+  bool init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& n);
+  void starting(const ros::Time& time);
+  void stopping(const ros::Time& time);
+  void update(const ros::Time& time, const ros::Duration& period);
+  void updateCommands();
 
-    bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n) ;
-    void starting(const ros::Time& time) ;
-    void stopping(const ros::Time& time) ;
-    void update(const ros::Time& time, const ros::Duration& period) ;
-    void updateCommands() ;
+private:
+  ros::NodeHandle nh_;
 
-  private:
-    ros::NodeHandle nh_;
+  /**< Last commanded position. */
+  realtime_tools::RealtimeBuffer<baxter_core_msgs::EndEffectorCommand> gripper_command_buffer;
 
-    /**< Last commanded position. */
-    realtime_tools::RealtimeBuffer<baxter_core_msgs::EndEffectorCommand> gripper_command_buffer;
+  size_t n_joints;
+  std::string topic_name;
+  // Indices for mimic and orignal joints
+  int mimic_idx_;
+  int main_idx_;
 
-    size_t n_joints;
-    std::string topic_name;
-    // Indices for mimic and orignal joints
-    int mimic_idx_;
-    int main_idx_;
+  std::map<std::string, std::size_t> joint_to_index_map;  // allows incoming messages to be quickly ordered
 
-    std::map<std::string,std::size_t> joint_to_index_map; // allows incoming messages to be quickly ordered
+  bool new_command;  // true when an unproccessed new command is in the realtime buffer
+  size_t update_counter;
 
-    bool new_command; // true when an unproccessed new command is in the realtime buffer
-    size_t update_counter;
+  // Command subscriber
+  ros::Subscriber gripper_command_sub;
 
-    // Command subscriber
-    ros::Subscriber gripper_command_sub;
+  /**
+   * @brief Callback from a recieved goal from the published topic message
+   * @param msg trajectory goal
+   */
+  void commandCB(const baxter_core_msgs::EndEffectorCommandConstPtr& msg);
 
-    /**
-     * @brief Callback from a recieved goal from the published topic message
-     * @param msg trajectory goal
-     */
-    void commandCB(const baxter_core_msgs::EndEffectorCommandConstPtr& msg);
+  // Create an effort-based joint position controller for every joint
+  std::vector<boost::shared_ptr<effort_controllers::JointPositionController> > gripper_controllers;
+};
 
-    // Create an effort-based joint position controller for every joint
-    std::vector<
-      boost::shared_ptr<
-        effort_controllers::JointPositionController> > gripper_controllers;
-  };
-
-} // namespace
+}  // namespace
 
 #endif /* BAXTER_GRIPPER_CONTROLLER_H_ */

--- a/baxter_sim_controllers/include/baxter_sim_controllers/baxter_position_controller.h
+++ b/baxter_sim_controllers/include/baxter_sim_controllers/baxter_position_controller.h
@@ -51,58 +51,52 @@
 #include <controller_interface/controller.h>
 #include <realtime_tools/realtime_buffer.h>
 
-#include <baxter_core_msgs/JointCommand.h> // the input command
+#include <baxter_core_msgs/JointCommand.h>  // the input command
 
-#include <effort_controllers/joint_position_controller.h> // used for controlling individual joints
-
+#include <effort_controllers/joint_position_controller.h>  // used for controlling individual joints
 
 namespace baxter_sim_controllers
 {
+class BaxterPositionController : public controller_interface::Controller<hardware_interface::EffortJointInterface>
+{
+public:
+  BaxterPositionController();
+  ~BaxterPositionController();
 
-  class BaxterPositionController: public controller_interface::Controller<hardware_interface::EffortJointInterface>
-  {
+  bool init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& n);
+  void starting(const ros::Time& time);
+  void stopping(const ros::Time& time);
+  void update(const ros::Time& time, const ros::Duration& period);
+  void updateCommands();
 
-  public:
-    BaxterPositionController();
-    ~BaxterPositionController();
+private:
+  ros::NodeHandle nh_;
 
-    bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
-    void starting(const ros::Time& time);
-    void stopping(const ros::Time& time);
-    void update(const ros::Time& time, const ros::Duration& period);
-    void updateCommands();
+  /**< Last commanded position. */
+  realtime_tools::RealtimeBuffer<baxter_core_msgs::JointCommand> position_command_buffer_;
 
-  private:
-    ros::NodeHandle nh_;
+  size_t n_joints_;
+  std::string topic_name;
 
-    /**< Last commanded position. */
-    realtime_tools::RealtimeBuffer<baxter_core_msgs::JointCommand> position_command_buffer_;
+  std::map<std::string, std::size_t> joint_to_index_map_;  // allows incoming messages to be quickly ordered
 
-    size_t n_joints_;
-    std::string topic_name;
+  bool verbose_;
+  bool new_command_;  // true when an unproccessed new command is in the realtime buffer
+  size_t update_counter_;
 
-    std::map<std::string,std::size_t> joint_to_index_map_; // allows incoming messages to be quickly ordered
+  // Command subscriber
+  ros::Subscriber position_command_sub_;
 
-    bool verbose_;
-    bool new_command_; // true when an unproccessed new command is in the realtime buffer
-    size_t update_counter_;
+  /**
+   * @brief Callback from a recieved goal from the published topic message
+   * @param msg trajectory goal
+   */
+  void commandCB(const baxter_core_msgs::JointCommandConstPtr& msg);
 
-    // Command subscriber
-    ros::Subscriber position_command_sub_;
+  // Create an effort-based joint position controller for every joint
+  std::vector<boost::shared_ptr<effort_controllers::JointPositionController> > position_controllers_;
+};
 
-    /**
-     * @brief Callback from a recieved goal from the published topic message
-     * @param msg trajectory goal
-     */
-    void commandCB(const baxter_core_msgs::JointCommandConstPtr& msg);
-
-    // Create an effort-based joint position controller for every joint
-    std::vector<
-      boost::shared_ptr<
-        effort_controllers::JointPositionController> > position_controllers_;
-
-  };
-
-} // namespace
+}  // namespace
 
 #endif

--- a/baxter_sim_controllers/include/baxter_sim_controllers/baxter_velocity_controller.h
+++ b/baxter_sim_controllers/include/baxter_sim_controllers/baxter_velocity_controller.h
@@ -51,58 +51,52 @@
 #include <controller_interface/controller.h>
 #include <realtime_tools/realtime_buffer.h>
 
-#include <baxter_core_msgs/JointCommand.h> // the input command
+#include <baxter_core_msgs/JointCommand.h>  // the input command
 
-#include <effort_controllers/joint_velocity_controller.h> // used for controlling individual joints
-
+#include <effort_controllers/joint_velocity_controller.h>  // used for controlling individual joints
 
 namespace baxter_sim_controllers
 {
+class BaxterVelocityController : public controller_interface::Controller<hardware_interface::EffortJointInterface>
+{
+public:
+  BaxterVelocityController();
+  ~BaxterVelocityController();
 
-  class BaxterVelocityController: public controller_interface::Controller<hardware_interface::EffortJointInterface>
-  {
+  bool init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& n);
+  void starting(const ros::Time& time);
+  void stopping(const ros::Time& time);
+  void update(const ros::Time& time, const ros::Duration& period);
+  void updateCommands();
 
-  public:
-    BaxterVelocityController();
-    ~BaxterVelocityController();
+private:
+  ros::NodeHandle nh_;
 
-    bool init(hardware_interface::EffortJointInterface *robot, ros::NodeHandle &n);
-    void starting(const ros::Time& time);
-    void stopping(const ros::Time& time);
-    void update(const ros::Time& time, const ros::Duration& period);
-    void updateCommands();
+  // Last commanded velocity
+  realtime_tools::RealtimeBuffer<baxter_core_msgs::JointCommand> velocity_command_buffer_;
 
-  private:
-    ros::NodeHandle nh_;
+  size_t n_joints_;
+  std::string topic_name;
 
-    // Last commanded velocity
-    realtime_tools::RealtimeBuffer<baxter_core_msgs::JointCommand> velocity_command_buffer_;
+  std::map<std::string, std::size_t> joint_to_index_map_;  // allows incoming messages to be quickly ordered
 
-    size_t n_joints_;
-    std::string topic_name;
+  bool verbose_;
+  bool new_command_;  // true when an unproccessed new command is in the realtime buffer
+  size_t update_counter_;
 
-    std::map<std::string,std::size_t> joint_to_index_map_; // allows incoming messages to be quickly ordered
+  // Command subscriber
+  ros::Subscriber velocity_command_sub_;
 
-    bool verbose_;
-    bool new_command_; // true when an unproccessed new command is in the realtime buffer
-    size_t update_counter_;
+  /**
+   * @brief Callback from a recieved goal from the published topic message
+   * @param msg trajectory goal
+   */
+  void commandCB(const baxter_core_msgs::JointCommandConstPtr& msg);
 
-    // Command subscriber
-    ros::Subscriber velocity_command_sub_;
+  // Create an effort-based joint velocity controller for every joint
+  std::vector<boost::shared_ptr<effort_controllers::JointVelocityController> > velocity_controllers_;
+};
 
-    /**
-     * @brief Callback from a recieved goal from the published topic message
-     * @param msg trajectory goal
-     */
-    void commandCB(const baxter_core_msgs::JointCommandConstPtr& msg);
-
-    // Create an effort-based joint velocity controller for every joint
-    std::vector<
-      boost::shared_ptr<
-        effort_controllers::JointVelocityController> > velocity_controllers_;
-
-  };
-
-} // namespace
+}  // namespace
 
 #endif

--- a/baxter_sim_controllers/src/baxter_effort_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_effort_controller.cpp
@@ -35,128 +35,121 @@
 #include <baxter_sim_controllers/baxter_effort_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-
-namespace baxter_sim_controllers {
-
-BaxterEffortController::BaxterEffortController()
-  : new_command_(true)
-    //update_counter_(0)
-{}
+namespace baxter_sim_controllers
+{
+BaxterEffortController::BaxterEffortController() : new_command_(true)
+// update_counter_(0)
+{
+}
 
 BaxterEffortController::~BaxterEffortController()
 {
   effort_command_sub_.shutdown();
 }
 
-bool BaxterEffortController::init(
-  hardware_interface::EffortJointInterface *robot, ros::NodeHandle &nh)
+bool BaxterEffortController::init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& nh)
 {
   // Store nodehandle
   nh_ = nh;
 
   // Get joint sub-controllers
   XmlRpc::XmlRpcValue xml_struct;
-  if( !nh_.getParam("joints", xml_struct) )
+  if (!nh_.getParam("joints", xml_struct))
   {
     ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Make sure it's a struct
-  if(xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {
-    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Get number of joints
   n_joints_ = xml_struct.size();
-  ROS_INFO_STREAM("Initializing BaxterEffortController with "<<n_joints_<<" joints.");
+  ROS_INFO_STREAM("Initializing BaxterEffortController with " << n_joints_ << " joints.");
 
   effort_controllers_.resize(n_joints_);
 
-  int i = 0; // track the joint id
-  for(XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin();
-      joint_it != xml_struct.end(); ++joint_it)
+  int i = 0;  // track the joint id
+  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin(); joint_it != xml_struct.end(); ++joint_it)
   {
     // Get joint controller
-    if(joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
     {
-      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
       return false;
     }
-	
+
     // Get joint names from the parameter server
-     std::string joint_name[n_joints_];
+    std::string joint_name[n_joints_];
     // Get joint controller name
     std::string joint_controller_name = joint_it->first;
 
     // Get the joint-namespace nodehandle
     {
-      ros::NodeHandle joint_nh(nh_, "joints/"+joint_controller_name);
-      ROS_INFO_STREAM_NAMED("init","Loading sub-controller '" << joint_controller_name
-        << "', Namespace: " << joint_nh.getNamespace());
+      ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
+      ROS_INFO_STREAM_NAMED("init", "Loading sub-controller '" << joint_controller_name
+                                                               << "', Namespace: " << joint_nh.getNamespace());
 
       effort_controllers_[i].reset(new effort_controllers::JointEffortController());
       effort_controllers_[i]->init(robot, joint_nh);
 
-      if( !joint_nh.getParam("joint",joint_name[i]))
+      if (!joint_nh.getParam("joint", joint_name[i]))
       {
-    	ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", joint_nh.getNamespace().c_str());
-    	return false;
+        ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", joint_nh.getNamespace().c_str());
+        return false;
       }
-	// Create a publisher for every joint controller that publishes to the command topic under that controller
-	effort_command_pub_[i]=joint_nh.advertise<std_msgs::Float64>("command",1);
+      // Create a publisher for every joint controller that publishes to the command topic under that controller
+      effort_command_pub_[i] = joint_nh.advertise<std_msgs::Float64>("command", 1);
 
-    } // end of joint-namespaces
+    }  // end of joint-namespaces
 
     // Add joint name to map (allows unordered list to quickly be mapped to the ordered index)
-    joint_to_index_map_.insert(std::pair<std::string,std::size_t>
-      (joint_name[i],i));
+    joint_to_index_map_.insert(std::pair<std::string, std::size_t>(joint_name[i], i));
     // increment joint i
     ++i;
   }
 
   // Get controller topic name that it will subscribe to
-  if( nh_.getParam("topic", topic_name) ) // They provided a custom topic to subscribe to
+  if (nh_.getParam("topic", topic_name))  // They provided a custom topic to subscribe to
   {
     // Get a node handle that is relative to the base path
     ros::NodeHandle nh_base("~");
 
     // Create command subscriber custom to baxter
-    effort_command_sub_ = nh_base.subscribe<baxter_core_msgs::JointCommand>
-      (topic_name, 1, &BaxterEffortController::commandCB, this);
+    effort_command_sub_ =
+        nh_base.subscribe<baxter_core_msgs::JointCommand>(topic_name, 1, &BaxterEffortController::commandCB, this);
   }
-  else // default "command" topic
+  else  // default "command" topic
   {
     // Create command subscriber custom to baxter
-    effort_command_sub_ = nh_.subscribe<baxter_core_msgs::JointCommand>
-      ("command", 1, &BaxterEffortController::commandCB, this);
+    effort_command_sub_ =
+        nh_.subscribe<baxter_core_msgs::JointCommand>("command", 1, &BaxterEffortController::commandCB, this);
   }
 
   return true;
 }
 
-
-
 void BaxterEffortController::starting(const ros::Time& time)
 {
-	for(int i=0; i<n_joints_; i++)
- 	  effort_controllers_[i]->starting(time);
+  for (int i = 0; i < n_joints_; i++)
+    effort_controllers_[i]->starting(time);
 }
 
 void BaxterEffortController::stopping(const ros::Time& time)
 {
-
 }
 
 void BaxterEffortController::update(const ros::Time& time, const ros::Duration& period)
 {
   // Check if there are commands to be updated
- if(!new_command_)
-	return;
- new_command_=false;
-  for(size_t i=0; i<n_joints_; i++)
+  if (!new_command_)
+    return;
+  new_command_ = false;
+  for (size_t i = 0; i < n_joints_; i++)
   {
     // Update the individual joint controllers
     effort_controllers_[i]->update(time, period);
@@ -165,34 +158,33 @@ void BaxterEffortController::update(const ros::Time& time, const ros::Duration& 
 
 void BaxterEffortController::commandCB(const baxter_core_msgs::JointCommandConstPtr& msg)
 {
-//Check if the number of joints and effort values are equal
-if( msg->command.size() != msg->names.size() )
+  // Check if the number of joints and effort values are equal
+  if (msg->command.size() != msg->names.size())
   {
-    ROS_ERROR_STREAM_NAMED("update","List of names does not match list of efforts size, "
-      << msg->command.size() << " != " << msg->names.size() );
+    ROS_ERROR_STREAM_NAMED("update", "List of names does not match list of efforts size, "
+                                         << msg->command.size() << " != " << msg->names.size());
     return;
   }
 
-std::map<std::string,std::size_t>::iterator name_it;
+  std::map<std::string, std::size_t>::iterator name_it;
   // Map incoming joint names and effort values to the correct internal ordering
-  for(size_t i=0; i<msg->names.size(); i++)
+  for (size_t i = 0; i < msg->names.size(); i++)
   {
     // Check if the joint name is in our map
     name_it = joint_to_index_map_.find(msg->names[i]);
 
-    if( name_it != joint_to_index_map_.end() )
+    if (name_it != joint_to_index_map_.end())
     {
       // Joint is in the map, so we'll update the joint effort
-	m.data=msg->command[i];
+      m.data = msg->command[i];
       // Publish the joint effort to the corresponding joint controller
-      effort_command_pub_[name_it->second].publish( m );
+      effort_command_pub_[name_it->second].publish(m);
     }
   }
-// Update that new effort values are waiting to be sent to the joints
+  // Update that new effort values are waiting to be sent to the joints
   new_command_ = true;
 }
 
+}  // namespace
 
-} // namespace
-
-PLUGINLIB_EXPORT_CLASS( baxter_sim_controllers::BaxterEffortController,controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterEffortController, controller_interface::ControllerBase)

--- a/baxter_sim_controllers/src/baxter_gripper_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_gripper_controller.cpp
@@ -31,53 +31,49 @@
 #include <pluginlib/class_list_macros.h>
 #include <yaml-cpp/yaml.h>
 
-namespace baxter_sim_controllers {
-
-BaxterGripperController::BaxterGripperController()
-    : new_command(true),
-      update_counter(0),
-      mimic_idx_(0),
-      main_idx_(0) {
+namespace baxter_sim_controllers
+{
+BaxterGripperController::BaxterGripperController() : new_command(true), update_counter(0), mimic_idx_(0), main_idx_(0)
+{
 }
 
-BaxterGripperController::~BaxterGripperController() {
-    gripper_command_sub.shutdown();
+BaxterGripperController::~BaxterGripperController()
+{
+  gripper_command_sub.shutdown();
 }
 
-bool BaxterGripperController::init(hardware_interface::EffortJointInterface *robot,
-                                ros::NodeHandle &nh) {
+bool BaxterGripperController::init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& nh)
+{
   // Store nodehandle
   nh_ = nh;
 
   // Get joint sub-controllers
   XmlRpc::XmlRpcValue xml_struct;
-  if (!nh_.getParam("joints", xml_struct)) {
-    ROS_ERROR("No 'joints' parameter in controller (namespace '%s')",
-              nh_.getNamespace().c_str());
+  if (!nh_.getParam("joints", xml_struct))
+  {
+    ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Make sure it's a struct
-  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",
-              nh_.getNamespace().c_str());
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Get number of joints
   n_joints = xml_struct.size();
-  ROS_INFO_STREAM(
-      "Initializing BaxterGripperController with "<<n_joints<<" joints.");
+  ROS_INFO_STREAM("Initializing BaxterGripperController with " << n_joints << " joints.");
 
   gripper_controllers.resize(n_joints);
   int i = 0;  // track the joint id
-  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin();
-      joint_it != xml_struct.end(); ++joint_it) {
+  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin(); joint_it != xml_struct.end(); ++joint_it)
+  {
     // Get joint controller
-    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-      ROS_ERROR(
-          "The 'joints/joint_controller' parameter is not a struct (namespace '%s')",
-          nh_.getNamespace().c_str());
+    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
       return false;
     }
 
@@ -87,35 +83,34 @@ bool BaxterGripperController::init(hardware_interface::EffortJointInterface *rob
     // Get the joint-namespace nodehandle
     {
       ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
-      ROS_INFO_STREAM_NAMED(
-          "init",
-          "Loading sub-controller '" << joint_controller_name << "', Namespace: " << joint_nh.getNamespace());
+      ROS_INFO_STREAM_NAMED("init", "Loading sub-controller '" << joint_controller_name
+                                                               << "', Namespace: " << joint_nh.getNamespace());
 
-      gripper_controllers[i].reset(
-          new effort_controllers::JointPositionController());
+      gripper_controllers[i].reset(new effort_controllers::JointPositionController());
       gripper_controllers[i]->init(robot, joint_nh);
 
     }  // end of joint-namespaces
 
     // Set mimic indices
-    if ( gripper_controllers[i]->joint_urdf_->mimic ) {
+    if (gripper_controllers[i]->joint_urdf_->mimic)
+    {
       mimic_idx_ = i;
     }
-    else{
+    else
+    {
       main_idx_ = i;
     }
 
     // Add joint name to map (allows unordered list to quickly be mapped to the ordered index)
-    joint_to_index_map.insert(
-        std::pair<std::string, std::size_t>(gripper_controllers[i]->getJointName(),
-                                            i));
+    joint_to_index_map.insert(std::pair<std::string, std::size_t>(gripper_controllers[i]->getJointName(), i));
 
     // increment joint i
     ++i;
   }
 
   // Get controller topic name that it will subscribe to
-  if (nh_.getParam("topic", topic_name)) { // They provided a custom topic to subscribe to
+  if (nh_.getParam("topic", topic_name))
+  {  // They provided a custom topic to subscribe to
 
     // Get a node handle that is relative to the base path
     ros::NodeHandle nh_base("~");
@@ -123,39 +118,44 @@ bool BaxterGripperController::init(hardware_interface::EffortJointInterface *rob
     // Create command subscriber custom to baxter
     gripper_command_sub = nh_base.subscribe<baxter_core_msgs::EndEffectorCommand>(
         topic_name, 1, &BaxterGripperController::commandCB, this);
-  } else  // default "command" topic
+  }
+  else  // default "command" topic
   {
     // Create command subscriber custom to baxter
-    gripper_command_sub = nh_.subscribe<baxter_core_msgs::EndEffectorCommand>(
-        "command", 1, &BaxterGripperController::commandCB, this);
+    gripper_command_sub =
+        nh_.subscribe<baxter_core_msgs::EndEffectorCommand>("command", 1, &BaxterGripperController::commandCB, this);
   }
   return true;
 }
 
-void BaxterGripperController::starting(const ros::Time& time) {
+void BaxterGripperController::starting(const ros::Time& time)
+{
 }
 
-void BaxterGripperController::stopping(const ros::Time& time) {
-
+void BaxterGripperController::stopping(const ros::Time& time)
+{
 }
 
-void BaxterGripperController::update(const ros::Time& time,
-                                  const ros::Duration& period) {
+void BaxterGripperController::update(const ros::Time& time, const ros::Duration& period)
+{
   // Debug info
   update_counter++;
-  //TODO: Change to ROS Param (20 Hz)
-  if (update_counter % 5 == 0) {
+  // TODO: Change to ROS Param (20 Hz)
+  if (update_counter % 5 == 0)
+  {
     updateCommands();
   }
 
   // Apply joint commands
-  for (size_t i = 0; i < n_joints; i++) {
+  for (size_t i = 0; i < n_joints; i++)
+  {
     // Update the individual joint controllers
     gripper_controllers[i]->update(time, period);
   }
 }
 
-void BaxterGripperController::updateCommands() {
+void BaxterGripperController::updateCommands()
+{
   // Check if we have a new command to publish
   if (!new_command)
     return;
@@ -164,38 +164,42 @@ void BaxterGripperController::updateCommands() {
   new_command = false;
 
   // Get latest command
-  const baxter_core_msgs::EndEffectorCommand &command = *(gripper_command_buffer
-      .readFromRT());
+  const baxter_core_msgs::EndEffectorCommand& command = *(gripper_command_buffer.readFromRT());
 
   ROS_DEBUG_STREAM("Gripper update commands " << command.command << " " << command.args);
-  if ( command.command != baxter_core_msgs::EndEffectorCommand::CMD_GO)
-      return;
+  if (command.command != baxter_core_msgs::EndEffectorCommand::CMD_GO)
+    return;
 
-  double cmd_position  = gripper_controllers[main_idx_]->getPosition();
-  #ifndef DEPRECATED_YAML_CPP_VERSION
+  double cmd_position = gripper_controllers[main_idx_]->getPosition();
+#ifndef DEPRECATED_YAML_CPP_VERSION
   YAML::Node args = YAML::Load(command.args);
-  if ( args["position"] ) {
+  if (args["position"])
+  {
     cmd_position = args["position"].as<double>();
     // Check Command Limits:
-    if(cmd_position < 0.0){
+    if (cmd_position < 0.0)
+    {
       cmd_position = 0.0;
     }
-    else if(cmd_position > 100.0){
+    else if (cmd_position > 100.0)
+    {
       cmd_position = 100.0;
     }
     // cmd = ratio * range
-    cmd_position = (cmd_position/100.0) *
-      (gripper_controllers[main_idx_]->joint_urdf_->limits->upper - gripper_controllers[main_idx_]->joint_urdf_->limits->lower);
+    cmd_position = (cmd_position / 100.0) * (gripper_controllers[main_idx_]->joint_urdf_->limits->upper -
+                                             gripper_controllers[main_idx_]->joint_urdf_->limits->lower);
   }
-  #endif
+#endif
   // Update the individual joint controllers
   ROS_DEBUG_STREAM(gripper_controllers[main_idx_]->joint_urdf_->name << "->setCommand(" << cmd_position << ")");
   gripper_controllers[main_idx_]->setCommand(cmd_position);
-  gripper_controllers[mimic_idx_]->setCommand(gripper_controllers[mimic_idx_]->joint_urdf_->mimic->multiplier*cmd_position+gripper_controllers[mimic_idx_]->joint_urdf_->mimic->offset);
+  gripper_controllers[mimic_idx_]->setCommand(gripper_controllers[mimic_idx_]->joint_urdf_->mimic->multiplier *
+                                                  cmd_position +
+                                              gripper_controllers[mimic_idx_]->joint_urdf_->mimic->offset);
 }
 
-void BaxterGripperController::commandCB(
-    const baxter_core_msgs::EndEffectorCommandConstPtr& msg) {
+void BaxterGripperController::commandCB(const baxter_core_msgs::EndEffectorCommandConstPtr& msg)
+{
   // the writeFromNonRT can be used in RT, if you have the guarantee that
   //  * no non-rt thread is calling the same function (we're not subscribing to ros callbacks)
   //  * there is only one single rt thread
@@ -206,5 +210,4 @@ void BaxterGripperController::commandCB(
 
 }  // namespace
 
-PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterGripperController,
-                       controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterGripperController, controller_interface::ControllerBase)

--- a/baxter_sim_controllers/src/baxter_head_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_head_controller.cpp
@@ -30,52 +30,50 @@
 #include <baxter_sim_controllers/baxter_head_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-namespace baxter_sim_controllers {
-
-BaxterHeadController::BaxterHeadController()
-    : new_command(true),
-      update_counter(0) {
+namespace baxter_sim_controllers
+{
+BaxterHeadController::BaxterHeadController() : new_command(true), update_counter(0)
+{
 }
 
-BaxterHeadController::~BaxterHeadController() {
+BaxterHeadController::~BaxterHeadController()
+{
   head_command_sub.shutdown();
 }
 
-bool BaxterHeadController::init(hardware_interface::EffortJointInterface *robot,
-                                ros::NodeHandle &nh) {
+bool BaxterHeadController::init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& nh)
+{
   // Store nodehandle
   nh_ = nh;
 
   // Get joint sub-controllers
   XmlRpc::XmlRpcValue xml_struct;
-  if (!nh_.getParam("joints", xml_struct)) {
-    ROS_ERROR("No 'joints' parameter in controller (namespace '%s')",
-              nh_.getNamespace().c_str());
+  if (!nh_.getParam("joints", xml_struct))
+  {
+    ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Make sure it's a struct
-  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",
-              nh_.getNamespace().c_str());
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  {
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Get number of joints
   n_joints = xml_struct.size();
-  ROS_INFO_STREAM(
-      "Initializing BaxterHeadController with "<<n_joints<<" joints.");
+  ROS_INFO_STREAM("Initializing BaxterHeadController with " << n_joints << " joints.");
 
   head_controllers.resize(n_joints);
 
   int i = 0;  // track the joint id
-  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin();
-      joint_it != xml_struct.end(); ++joint_it) {
+  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin(); joint_it != xml_struct.end(); ++joint_it)
+  {
     // Get joint controller
-    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct) {
-      ROS_ERROR(
-          "The 'joints/joint_controller' parameter is not a struct (namespace '%s')",
-          nh_.getNamespace().c_str());
+    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    {
+      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
       return false;
     }
 
@@ -85,75 +83,77 @@ bool BaxterHeadController::init(hardware_interface::EffortJointInterface *robot,
     // Get the joint-namespace nodehandle
     {
       ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
-      ROS_INFO_STREAM_NAMED(
-          "init",
-          "Loading sub-controller '" << joint_controller_name << "', Namespace: " << joint_nh.getNamespace());
+      ROS_INFO_STREAM_NAMED("init", "Loading sub-controller '" << joint_controller_name
+                                                               << "', Namespace: " << joint_nh.getNamespace());
 
-      head_controllers[i].reset(
-          new effort_controllers::JointPositionController());
+      head_controllers[i].reset(new effort_controllers::JointPositionController());
       head_controllers[i]->init(robot, joint_nh);
 
     }  // end of joint-namespaces
 
     // Add joint name to map (allows unordered list to quickly be mapped to the ordered index)
-    joint_to_index_map.insert(
-        std::pair<std::string, std::size_t>(head_controllers[i]->getJointName(),
-                                            i));
+    joint_to_index_map.insert(std::pair<std::string, std::size_t>(head_controllers[i]->getJointName(), i));
 
     // increment joint i
     ++i;
   }
 
   // Get controller topic name that it will subscribe to
-  if (nh_.getParam("topic", topic_name)) { // They provided a custom topic to subscribe to
+  if (nh_.getParam("topic", topic_name))
+  {  // They provided a custom topic to subscribe to
 
     // Get a node handle that is relative to the base path
     ros::NodeHandle nh_base("~");
 
     // Create command subscriber custom to baxter
-    head_command_sub = nh_base.subscribe<baxter_core_msgs::HeadPanCommand>(
-        topic_name, 1, &BaxterHeadController::commandCB, this);
-  } else  // default "command" topic
+    head_command_sub =
+        nh_base.subscribe<baxter_core_msgs::HeadPanCommand>(topic_name, 1, &BaxterHeadController::commandCB, this);
+  }
+  else  // default "command" topic
   {
     // Create command subscriber custom to baxter
-    head_command_sub = nh_.subscribe<baxter_core_msgs::HeadPanCommand>(
-        "command", 1, &BaxterHeadController::commandCB, this);
+    head_command_sub =
+        nh_.subscribe<baxter_core_msgs::HeadPanCommand>("command", 1, &BaxterHeadController::commandCB, this);
   }
 
   return true;
 }
 
-void BaxterHeadController::starting(const ros::Time& time) {
+void BaxterHeadController::starting(const ros::Time& time)
+{
   baxter_core_msgs::HeadPanCommand initial_command;
 
   // Fill in the initial command
-  for (int i = 0; i < n_joints; i++) {
+  for (int i = 0; i < n_joints; i++)
+  {
     initial_command.target = head_controllers[i]->getPosition();
   }
   head_command_buffer.initRT(initial_command);
   new_command = true;
 }
 
-void BaxterHeadController::stopping(const ros::Time& time) {
-
+void BaxterHeadController::stopping(const ros::Time& time)
+{
 }
 
-void BaxterHeadController::update(const ros::Time& time,
-                                  const ros::Duration& period) {
+void BaxterHeadController::update(const ros::Time& time, const ros::Duration& period)
+{
   // Debug info
   update_counter++;
   if (update_counter % 100 == 0)
 
-  updateCommands();
+    updateCommands();
 
   // Apply joint commands
-  for (size_t i = 0; i < n_joints; i++) {
+  for (size_t i = 0; i < n_joints; i++)
+  {
     // Update the individual joint controllers
     head_controllers[i]->update(time, period);
   }
 }
 
-void BaxterHeadController::updateCommands() {
+void BaxterHeadController::updateCommands()
+{
   // Check if we have a new command to publish
   if (!new_command)
     return;
@@ -162,14 +162,13 @@ void BaxterHeadController::updateCommands() {
   new_command = false;
 
   // Get latest command
-  const baxter_core_msgs::HeadPanCommand &command = *(head_command_buffer
-      .readFromRT());
+  const baxter_core_msgs::HeadPanCommand& command = *(head_command_buffer.readFromRT());
 
   head_controllers[0]->setCommand(command.target);
 }
 
-void BaxterHeadController::commandCB(
-    const baxter_core_msgs::HeadPanCommandConstPtr& msg) {
+void BaxterHeadController::commandCB(const baxter_core_msgs::HeadPanCommandConstPtr& msg)
+{
   // the writeFromNonRT can be used in RT, if you have the guarantee that
   //  * no non-rt thread is calling the same function (we're not subscribing to ros callbacks)
   //  * there is only one single rt thread
@@ -180,6 +179,4 @@ void BaxterHeadController::commandCB(
 
 }  // namespace
 
-PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterHeadController,
-                       controller_interface::ControllerBase)
-
+PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterHeadController, controller_interface::ControllerBase)

--- a/baxter_sim_controllers/src/baxter_position_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_position_controller.cpp
@@ -41,53 +41,50 @@
 #include <baxter_sim_controllers/baxter_position_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-namespace baxter_sim_controllers {
-
-BaxterPositionController::BaxterPositionController()
-  : new_command_(true),
-    update_counter_(0)
-{}
+namespace baxter_sim_controllers
+{
+BaxterPositionController::BaxterPositionController() : new_command_(true), update_counter_(0)
+{
+}
 
 BaxterPositionController::~BaxterPositionController()
 {
   position_command_sub_.shutdown();
 }
 
-bool BaxterPositionController::init(
-  hardware_interface::EffortJointInterface *robot, ros::NodeHandle &nh)
+bool BaxterPositionController::init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& nh)
 {
   // Store nodehandle
   nh_ = nh;
 
   // Get joint sub-controllers
   XmlRpc::XmlRpcValue xml_struct;
-  if( !nh_.getParam("joints", xml_struct) )
+  if (!nh_.getParam("joints", xml_struct))
   {
     ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Make sure it's a struct
-  if(xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {
-    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Get number of joints
   n_joints_ = xml_struct.size();
-  ROS_INFO_STREAM("Initializing BaxterPositionController with "<<n_joints_<<" joints.");
+  ROS_INFO_STREAM("Initializing BaxterPositionController with " << n_joints_ << " joints.");
 
   position_controllers_.resize(n_joints_);
 
-  int i = 0; // track the joint id
-  for(XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin();
-      joint_it != xml_struct.end(); ++joint_it)
+  int i = 0;  // track the joint id
+  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin(); joint_it != xml_struct.end(); ++joint_it)
   {
     // Get joint controller
-    if(joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
     {
-      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
       return false;
     }
 
@@ -96,56 +93,53 @@ bool BaxterPositionController::init(
 
     // Get the joint-namespace nodehandle
     {
-      ros::NodeHandle joint_nh(nh_, "joints/"+joint_controller_name);
-      ROS_INFO_STREAM_NAMED("init","Loading sub-controller '" << joint_controller_name
-        << "', Namespace: " << joint_nh.getNamespace());
+      ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
+      ROS_INFO_STREAM_NAMED("init", "Loading sub-controller '" << joint_controller_name
+                                                               << "', Namespace: " << joint_nh.getNamespace());
 
       position_controllers_[i].reset(new effort_controllers::JointPositionController());
       position_controllers_[i]->init(robot, joint_nh);
 
       // DEBUG
-      //position_controllers_[i]->printDebug();
+      // position_controllers_[i]->printDebug();
 
-    } // end of joint-namespaces
+    }  // end of joint-namespaces
 
     // Add joint name to map (allows unordered list to quickly be mapped to the ordered index)
-    joint_to_index_map_.insert(std::pair<std::string,std::size_t>
-      (position_controllers_[i]->getJointName(),i));
+    joint_to_index_map_.insert(std::pair<std::string, std::size_t>(position_controllers_[i]->getJointName(), i));
 
     // increment joint i
     ++i;
   }
 
   // Get controller topic name that it will subscribe to
-  if( nh_.getParam("topic", topic_name) ) // They provided a custom topic to subscribe to
+  if (nh_.getParam("topic", topic_name))  // They provided a custom topic to subscribe to
   {
     // Get a node handle that is relative to the base path
     ros::NodeHandle nh_base("~");
 
     // Create command subscriber custom to baxter
-    position_command_sub_ = nh_base.subscribe<baxter_core_msgs::JointCommand>
-      (topic_name, 1, &BaxterPositionController::commandCB, this);
+    position_command_sub_ =
+        nh_base.subscribe<baxter_core_msgs::JointCommand>(topic_name, 1, &BaxterPositionController::commandCB, this);
   }
-  else // default "command" topic
+  else  // default "command" topic
   {
     // Create command subscriber custom to baxter
-    position_command_sub_ = nh_.subscribe<baxter_core_msgs::JointCommand>
-      ("command", 1, &BaxterPositionController::commandCB, this);
+    position_command_sub_ =
+        nh_.subscribe<baxter_core_msgs::JointCommand>("command", 1, &BaxterPositionController::commandCB, this);
   }
 
   return true;
 }
-
-
 
 void BaxterPositionController::starting(const ros::Time& time)
 {
   baxter_core_msgs::JointCommand initial_command;
 
   // Fill in the initial command
-  for(int i=0; i<n_joints_; i++)
+  for (int i = 0; i < n_joints_; i++)
   {
-    initial_command.names.push_back( position_controllers_[i]->getJointName());
+    initial_command.names.push_back(position_controllers_[i]->getJointName());
     initial_command.command.push_back(position_controllers_[i]->getPosition());
   }
   position_command_buffer_.initRT(initial_command);
@@ -154,21 +148,20 @@ void BaxterPositionController::starting(const ros::Time& time)
 
 void BaxterPositionController::stopping(const ros::Time& time)
 {
-
 }
 
 void BaxterPositionController::update(const ros::Time& time, const ros::Duration& period)
 {
   // Debug info
   verbose_ = false;
-  update_counter_ ++;
-  if( update_counter_ % 100 == 0 )
+  update_counter_++;
+  if (update_counter_ % 100 == 0)
     verbose_ = true;
 
   updateCommands();
 
   // Apply joint commands
-  for(size_t i=0; i<n_joints_; i++)
+  for (size_t i = 0; i < n_joints_; i++)
   {
     // Update the individual joint controllers
     position_controllers_[i]->update(time, period);
@@ -178,35 +171,35 @@ void BaxterPositionController::update(const ros::Time& time, const ros::Duration
 void BaxterPositionController::updateCommands()
 {
   // Check if we have a new command to publish
-  if( !new_command_ )
+  if (!new_command_)
     return;
 
   // Go ahead and assume we have proccessed the current message
   new_command_ = false;
 
   // Get latest command
-  const baxter_core_msgs::JointCommand &command = *(position_command_buffer_.readFromRT());
+  const baxter_core_msgs::JointCommand& command = *(position_command_buffer_.readFromRT());
 
   // Error check message data
-  if( command.command.size() != command.names.size() )
+  if (command.command.size() != command.names.size())
   {
-    ROS_ERROR_STREAM_NAMED("update","List of names does not match list of angles size, "
-      << command.command.size() << " != " << command.names.size() );
+    ROS_ERROR_STREAM_NAMED("update", "List of names does not match list of angles size, "
+                                         << command.command.size() << " != " << command.names.size());
     return;
   }
 
-  std::map<std::string,std::size_t>::iterator name_it;
+  std::map<std::string, std::size_t>::iterator name_it;
 
   // Map incoming joint names and angles to the correct internal ordering
-  for(size_t i=0; i<command.names.size(); i++)
+  for (size_t i = 0; i < command.names.size(); i++)
   {
     // Check if the joint name is in our map
     name_it = joint_to_index_map_.find(command.names[i]);
 
-    if( name_it != joint_to_index_map_.end() )
+    if (name_it != joint_to_index_map_.end())
     {
       // Joint is in the map, so we'll update the joint position
-      position_controllers_[name_it->second]->setCommand( command.command[i] );
+      position_controllers_[name_it->second]->setCommand(command.command[i]);
     }
   }
 }
@@ -221,7 +214,6 @@ void BaxterPositionController::commandCB(const baxter_core_msgs::JointCommandCon
   new_command_ = true;
 }
 
+}  // namespace
 
-} // namespace
-
-PLUGINLIB_EXPORT_CLASS( baxter_sim_controllers::BaxterPositionController,controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterPositionController, controller_interface::ControllerBase)

--- a/baxter_sim_controllers/src/baxter_velocity_controller.cpp
+++ b/baxter_sim_controllers/src/baxter_velocity_controller.cpp
@@ -41,53 +41,50 @@
 #include <baxter_sim_controllers/baxter_velocity_controller.h>
 #include <pluginlib/class_list_macros.h>
 
-namespace baxter_sim_controllers {
-
-BaxterVelocityController::BaxterVelocityController()
-  : new_command_(true),
-    update_counter_(0)
-{}
+namespace baxter_sim_controllers
+{
+BaxterVelocityController::BaxterVelocityController() : new_command_(true), update_counter_(0)
+{
+}
 
 BaxterVelocityController::~BaxterVelocityController()
 {
   velocity_command_sub_.shutdown();
 }
 
-bool BaxterVelocityController::init(
-  hardware_interface::EffortJointInterface *robot, ros::NodeHandle &nh)
+bool BaxterVelocityController::init(hardware_interface::EffortJointInterface* robot, ros::NodeHandle& nh)
 {
   // Store nodehandle
   nh_ = nh;
 
   // Get joint sub-controllers
   XmlRpc::XmlRpcValue xml_struct;
-  if( !nh_.getParam("joints", xml_struct) )
+  if (!nh_.getParam("joints", xml_struct))
   {
     ROS_ERROR("No 'joints' parameter in controller (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Make sure it's a struct
-  if(xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+  if (xml_struct.getType() != XmlRpc::XmlRpcValue::TypeStruct)
   {
-    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+    ROS_ERROR("The 'joints' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
     return false;
   }
 
   // Get number of joints
   n_joints_ = xml_struct.size();
-  ROS_INFO_STREAM("Initializing BaxterVelocityController with "<<n_joints_<<" joints.");
+  ROS_INFO_STREAM("Initializing BaxterVelocityController with " << n_joints_ << " joints.");
 
   velocity_controllers_.resize(n_joints_);
 
-  int i = 0; // track the joint id
-  for(XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin();
-      joint_it != xml_struct.end(); ++joint_it)
+  int i = 0;  // track the joint id
+  for (XmlRpc::XmlRpcValue::iterator joint_it = xml_struct.begin(); joint_it != xml_struct.end(); ++joint_it)
   {
     // Get joint controller
-    if(joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
+    if (joint_it->second.getType() != XmlRpc::XmlRpcValue::TypeStruct)
     {
-      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')",nh_.getNamespace().c_str());
+      ROS_ERROR("The 'joints/joint_controller' parameter is not a struct (namespace '%s')", nh_.getNamespace().c_str());
       return false;
     }
 
@@ -96,56 +93,53 @@ bool BaxterVelocityController::init(
 
     // Get the joint-namespace nodehandle
     {
-      ros::NodeHandle joint_nh(nh_, "joints/"+joint_controller_name);
-      ROS_INFO_STREAM_NAMED("init","Loading sub-controller '" << joint_controller_name
-        << "', Namespace: " << joint_nh.getNamespace());
+      ros::NodeHandle joint_nh(nh_, "joints/" + joint_controller_name);
+      ROS_INFO_STREAM_NAMED("init", "Loading sub-controller '" << joint_controller_name
+                                                               << "', Namespace: " << joint_nh.getNamespace());
 
       velocity_controllers_[i].reset(new effort_controllers::JointVelocityController());
       velocity_controllers_[i]->init(robot, joint_nh);
 
       // DEBUG
-      //velocity_controllers_[i]->printDebug();
+      // velocity_controllers_[i]->printDebug();
 
-    } // end of joint-namespaces
+    }  // end of joint-namespaces
 
     // Add joint name to map (allows unordered list to quickly be mapped to the ordered index)
-    joint_to_index_map_.insert(std::pair<std::string,std::size_t>
-      (velocity_controllers_[i]->getJointName(),i));
+    joint_to_index_map_.insert(std::pair<std::string, std::size_t>(velocity_controllers_[i]->getJointName(), i));
 
     // increment joint i
     ++i;
   }
 
   // Get controller topic name that it will subscribe to
-  if( nh_.getParam("topic", topic_name) ) // They provided a custom topic to subscribe to
+  if (nh_.getParam("topic", topic_name))  // They provided a custom topic to subscribe to
   {
     // Get a node handle that is relative to the base path
     ros::NodeHandle nh_base("~");
 
     // Create command subscriber custom to baxter
-    velocity_command_sub_ = nh_base.subscribe<baxter_core_msgs::JointCommand>
-      (topic_name, 1, &BaxterVelocityController::commandCB, this);
+    velocity_command_sub_ =
+        nh_base.subscribe<baxter_core_msgs::JointCommand>(topic_name, 1, &BaxterVelocityController::commandCB, this);
   }
-  else // default "command" topic
+  else  // default "command" topic
   {
     // Create command subscriber custom to baxter
-    velocity_command_sub_ = nh_.subscribe<baxter_core_msgs::JointCommand>
-      ("command", 1, &BaxterVelocityController::commandCB, this);
+    velocity_command_sub_ =
+        nh_.subscribe<baxter_core_msgs::JointCommand>("command", 1, &BaxterVelocityController::commandCB, this);
   }
 
   return true;
 }
-
-
 
 void BaxterVelocityController::starting(const ros::Time& time)
 {
   baxter_core_msgs::JointCommand initial_command;
 
   // Fill in the initial command
-  for(int i=0; i<n_joints_; i++)
+  for (int i = 0; i < n_joints_; i++)
   {
-    initial_command.names.push_back( velocity_controllers_[i]->getJointName());
+    initial_command.names.push_back(velocity_controllers_[i]->getJointName());
     initial_command.command.push_back(0);
   }
   velocity_command_buffer_.initRT(initial_command);
@@ -154,21 +148,20 @@ void BaxterVelocityController::starting(const ros::Time& time)
 
 void BaxterVelocityController::stopping(const ros::Time& time)
 {
-
 }
 
 void BaxterVelocityController::update(const ros::Time& time, const ros::Duration& period)
 {
   // Debug info
   verbose_ = false;
-  update_counter_ ++;
-  if( update_counter_ % 100 == 0 )
+  update_counter_++;
+  if (update_counter_ % 100 == 0)
     verbose_ = true;
 
   updateCommands();
 
   // Apply joint commands
-  for(size_t i=0; i<n_joints_; i++)
+  for (size_t i = 0; i < n_joints_; i++)
   {
     // Update the individual joint controllers
     velocity_controllers_[i]->update(time, period);
@@ -178,35 +171,35 @@ void BaxterVelocityController::update(const ros::Time& time, const ros::Duration
 void BaxterVelocityController::updateCommands()
 {
   // Check if we have a new command to publish
-  if( !new_command_ )
+  if (!new_command_)
     return;
 
   // Go ahead and assume we have proccessed the current message
   new_command_ = false;
 
   // Get latest command
-  const baxter_core_msgs::JointCommand &command = *(velocity_command_buffer_.readFromRT());
+  const baxter_core_msgs::JointCommand& command = *(velocity_command_buffer_.readFromRT());
 
   // Error check message data
-  if( command.command.size() != command.names.size() )
+  if (command.command.size() != command.names.size())
   {
-    ROS_ERROR_STREAM_NAMED("update","List of names does not match list of velocities size, "
-      << command.command.size() << " != " << command.names.size() );
+    ROS_ERROR_STREAM_NAMED("update", "List of names does not match list of velocities size, "
+                                         << command.command.size() << " != " << command.names.size());
     return;
   }
 
-  std::map<std::string,std::size_t>::iterator name_it;
+  std::map<std::string, std::size_t>::iterator name_it;
 
   // Map incoming joint names and velocities to the correct internal ordering
-  for(size_t i=0; i<command.names.size(); i++)
+  for (size_t i = 0; i < command.names.size(); i++)
   {
     // Check if the joint name is in our map
     name_it = joint_to_index_map_.find(command.names[i]);
 
-    if( name_it != joint_to_index_map_.end() )
+    if (name_it != joint_to_index_map_.end())
     {
       // Joint is in the map, so we'll update the joint velocity
-      velocity_controllers_[name_it->second]->setCommand( command.command[i] );
+      velocity_controllers_[name_it->second]->setCommand(command.command[i]);
     }
   }
 }
@@ -221,7 +214,6 @@ void BaxterVelocityController::commandCB(const baxter_core_msgs::JointCommandCon
   new_command_ = true;
 }
 
+}  // namespace
 
-} // namespace
-
-PLUGINLIB_EXPORT_CLASS( baxter_sim_controllers::BaxterVelocityController,controller_interface::ControllerBase)
+PLUGINLIB_EXPORT_CLASS(baxter_sim_controllers::BaxterVelocityController, controller_interface::ControllerBase)

--- a/baxter_sim_hardware/include/baxter_sim_hardware/baxter_emulator.h
+++ b/baxter_sim_hardware/include/baxter_sim_hardware/baxter_emulator.h
@@ -41,7 +41,7 @@
 #include <std_msgs/Empty.h>
 #include <std_msgs/UInt32.h>
 
-//Baxter Specific Messages
+// Baxter Specific Messages
 #include <baxter_core_msgs/AssemblyState.h>
 #include <baxter_core_msgs/EndEffectorState.h>
 #include <baxter_core_msgs/EndEffectorProperties.h>
@@ -54,7 +54,7 @@
 
 #include <sensor_msgs/JointState.h>
 
-//ROS-Opencv Headers
+// ROS-Opencv Headers
 #include <image_transport/image_transport.h>
 #include <opencv2/highgui/highgui.hpp>
 #include <cv_bridge/cv_bridge.h>
@@ -67,16 +67,17 @@
 #include <cmath>
 #include <map>
 
-namespace baxter_en {
-
-class baxter_emulator {
-
- public:
+namespace baxter_en
+{
+class baxter_emulator
+{
+public:
   /**
    * Method to initialize the default values for all the variables, instantiate the publishers and 	* subscribers
    * @param img_path that refers the path of the image that loads on start up
    */
-  baxter_emulator() {
+  baxter_emulator()
+  {
   }
   bool init();
 
@@ -85,25 +86,20 @@ class baxter_emulator {
    * @param Nodehandle to initialize the image transport
    * @param img_path that refers the path of the image that loads on start up
    */
-  void publish(const std::string &img_path);
+  void publish(const std::string& img_path);
 
- private:
+private:
   bool enable;
-  //Subscribers
-  ros::Subscriber enable_sub, stop_sub, reset_sub, left_laser_sub,
-      right_laser_sub, nav_light_sub, head_nod_sub, jnt_st;
+  // Subscribers
+  ros::Subscriber enable_sub, stop_sub, reset_sub, left_laser_sub, right_laser_sub, nav_light_sub, head_nod_sub, jnt_st;
 
   // Gripper Publishers
-  ros::Publisher left_grip_st_pub, right_grip_st_pub, left_grip_prop_pub,
-      right_grip_prop_pub;
+  ros::Publisher left_grip_st_pub, right_grip_st_pub, left_grip_prop_pub, right_grip_prop_pub;
   // Infrared publishers
-  ros::Publisher left_ir_pub, right_ir_pub, left_ir_int_pub, right_ir_int_pub,
-      left_ir_state_pub, right_ir_state_pub;
+  ros::Publisher left_ir_pub, right_ir_pub, left_ir_int_pub, right_ir_int_pub, left_ir_state_pub, right_ir_state_pub;
   // Navigator publishers
-  ros::Publisher left_inner_light_pub, right_inner_light_pub,
-                 left_outer_light_pub, right_outer_light_pub,
-                 torso_left_inner_light_pub, torso_right_inner_light_pub,
-                 torso_left_outer_light_pub, torso_right_outer_light_pub;
+  ros::Publisher left_inner_light_pub, right_inner_light_pub, left_outer_light_pub, right_outer_light_pub,
+      torso_left_inner_light_pub, torso_right_inner_light_pub, torso_left_outer_light_pub, torso_right_outer_light_pub;
   // General state publishers
   ros::Publisher assembly_state_pub, head_pub;
   // Gravity Publishers
@@ -119,9 +115,8 @@ class baxter_emulator {
   baxter_core_msgs::EndEffectorState left_grip_st, right_grip_st;
   baxter_core_msgs::EndEffectorProperties left_grip_prop, right_grip_prop;
   baxter_core_msgs::AnalogIOState left_ir_state, right_ir_state;
-  baxter_core_msgs::DigitalIOState leftIL_nav_light, leftOL_nav_light,
-      torso_leftIL_nav_light, torso_leftOL_nav_light, rightIL_nav_light,
-      rightOL_nav_light, torso_rightIL_nav_light, torso_rightOL_nav_light;
+  baxter_core_msgs::DigitalIOState leftIL_nav_light, leftOL_nav_light, torso_leftIL_nav_light, torso_leftOL_nav_light,
+      rightIL_nav_light, rightOL_nav_light, torso_rightIL_nav_light, torso_rightOL_nav_light;
   baxter_core_msgs::SEAJointState left_gravity, right_gravity;
   sensor_msgs::JointState jstate_msg;
   sensor_msgs::Range left_ir, right_ir;
@@ -132,45 +127,44 @@ class baxter_emulator {
   /**
    * Callback function to enable the robot
    */
-  void enable_cb(const std_msgs::Bool &msg);
+  void enable_cb(const std_msgs::Bool& msg);
 
   /**
    * Callback function to stop the robot and capture the source of the stop
    */
-  void stop_cb(const std_msgs::Empty &msg);
+  void stop_cb(const std_msgs::Empty& msg);
 
   /**
    * Callback function to reset all the state values to False and 0s
    */
-  void reset_cb(const std_msgs::Empty &msg);
+  void reset_cb(const std_msgs::Empty& msg);
 
   /**
    * Callback function to update the left laser values
    */
-  void left_laser_cb(const sensor_msgs::LaserScan &msg);
+  void left_laser_cb(const sensor_msgs::LaserScan& msg);
 
   /**
    * Callback function to update the right laser values
    */
-  void right_laser_cb(const sensor_msgs::LaserScan &msg);
+  void right_laser_cb(const sensor_msgs::LaserScan& msg);
 
   /**
    * Callback function to update the navigators' light values
    */
-  void nav_light_cb(const baxter_core_msgs::DigitalOutputCommand &msg);
+  void nav_light_cb(const baxter_core_msgs::DigitalOutputCommand& msg);
 
   /**
    * Callback function to capture if the head is nodding
    */
-  void head_nod_cb(const std_msgs::Bool &msg);
+  void head_nod_cb(const std_msgs::Bool& msg);
 
   /**
    * Method that updates the gravity variable
    */
-  void update_jnt_st(const sensor_msgs::JointState &msg);
+  void update_jnt_st(const sensor_msgs::JointState& msg);
 
-  void reset_head_nod(const ros::TimerEvent &t);
-
+  void reset_head_nod(const ros::TimerEvent& t);
 };
 }  // namespace
 

--- a/baxter_sim_hardware/src/baxter_emulator.cpp
+++ b/baxter_sim_hardware/src/baxter_emulator.cpp
@@ -35,8 +35,8 @@
 
 #include <baxter_sim_hardware/baxter_emulator.h>
 
-namespace baxter_en {
-
+namespace baxter_en
+{
 // Topics to subscribe and publish
 const std::string BAXTER_STATE_TOPIC = "robot/state";
 const std::string BAXTER_ENABLE_TOPIC = "robot/set_super_enable";
@@ -44,51 +44,32 @@ const std::string BAXTER_STOP_TOPIC = "robot/set_super_stop";
 const std::string BAXTER_RESET_TOPIC = "robot/set_super_reset";
 const std::string BAXTER_DISPLAY_TOPIC = "robot/xdisplay";
 
-const std::string BAXTER_LEFT_GRIPPER_ST =
-    "robot/end_effector/left_gripper/state";
-const std::string BAXTER_RIGHT_GRIPPER_ST =
-    "robot/end_effector/right_gripper/state";
-const std::string BAXTER_LEFT_GRIPPER_PROP =
-    "robot/end_effector/left_gripper/properties";
-const std::string BAXTER_RIGHT_GRIPPER_PROP =
-    "robot/end_effector/right_gripper/properties";
+const std::string BAXTER_LEFT_GRIPPER_ST = "robot/end_effector/left_gripper/state";
+const std::string BAXTER_RIGHT_GRIPPER_ST = "robot/end_effector/right_gripper/state";
+const std::string BAXTER_LEFT_GRIPPER_PROP = "robot/end_effector/left_gripper/properties";
+const std::string BAXTER_RIGHT_GRIPPER_PROP = "robot/end_effector/right_gripper/properties";
 const std::string BAXTER_JOINT_TOPIC = "robot/joint_states";
-const std::string BAXTER_LEFT_LASER_TOPIC =
-    "sim/laserscan/left_hand_range/state";
-const std::string BAXTER_RIGHT_LASER_TOPIC =
-    "sim/laserscan/right_hand_range/state";
+const std::string BAXTER_LEFT_LASER_TOPIC = "sim/laserscan/left_hand_range/state";
+const std::string BAXTER_RIGHT_LASER_TOPIC = "sim/laserscan/right_hand_range/state";
 const std::string BAXTER_LEFT_IR_TOPIC = "robot/range/left_hand_range/state";
 const std::string BAXTER_RIGHT_IR_TOPIC = "robot/range/right_hand_range/state";
-const std::string BAXTER_LEFT_IR_STATE_TOPIC =
-    "robot/analog_io/left_hand_range/state";
-const std::string BAXTER_RIGHT_IR_STATE_TOPIC =
-    "robot/analog_io/right_hand_range/state";
-const std::string BAXTER_LEFT_IR_INT_TOPIC =
-    "robot/analog_io/left_hand_range/value_uint32";
-const std::string BAXTER_RIGHT_IR_INT_TOPIC =
-    "robot/analog_io/right_hand_range/value_uint32";
+const std::string BAXTER_LEFT_IR_STATE_TOPIC = "robot/analog_io/left_hand_range/state";
+const std::string BAXTER_RIGHT_IR_STATE_TOPIC = "robot/analog_io/right_hand_range/state";
+const std::string BAXTER_LEFT_IR_INT_TOPIC = "robot/analog_io/left_hand_range/value_uint32";
+const std::string BAXTER_RIGHT_IR_INT_TOPIC = "robot/analog_io/right_hand_range/value_uint32";
 
 const std::string BAXTER_NAV_LIGHT_TOPIC = "robot/digital_io/command";
-const std::string BAXTER_LEFTIL_TOPIC =
-    "robot/digital_io/left_inner_light/state";
-const std::string BAXTER_LEFTOL_TOPIC =
-    "robot/digital_io/left_outer_light/state";
-const std::string BAXTER_TORSO_LEFTIL_TOPIC =
-    "robot/digital_io/torso_left_inner_light/state";
-const std::string BAXTER_TORSO_LEFTOL_TOPIC =
-    "robot/digital_io/torso_left_outer_light/state";
-const std::string BAXTER_RIGHTIL_TOPIC =
-    "robot/digital_io/right_inner_light/state";
-const std::string BAXTER_RIGHTOL_TOPIC =
-    "robot/digital_io/right_outer_light/state";
-const std::string BAXTER_TORSO_RIGHTIL_TOPIC =
-    "robot/digital_io/torso_right_inner_light/state";
-const std::string BAXTER_TORSO_RIGHTOL_TOPIC =
-    "robot/digital_io/torso_right_outer_light/state";
+const std::string BAXTER_LEFTIL_TOPIC = "robot/digital_io/left_inner_light/state";
+const std::string BAXTER_LEFTOL_TOPIC = "robot/digital_io/left_outer_light/state";
+const std::string BAXTER_TORSO_LEFTIL_TOPIC = "robot/digital_io/torso_left_inner_light/state";
+const std::string BAXTER_TORSO_LEFTOL_TOPIC = "robot/digital_io/torso_left_outer_light/state";
+const std::string BAXTER_RIGHTIL_TOPIC = "robot/digital_io/right_inner_light/state";
+const std::string BAXTER_RIGHTOL_TOPIC = "robot/digital_io/right_outer_light/state";
+const std::string BAXTER_TORSO_RIGHTIL_TOPIC = "robot/digital_io/torso_right_inner_light/state";
+const std::string BAXTER_TORSO_RIGHTOL_TOPIC = "robot/digital_io/torso_right_outer_light/state";
 
 const std::string BAXTER_HEAD_STATE_TOPIC = "robot/head/head_state";
-const std::string BAXTER_HEAD_NOD_CMD_TOPIC =
-    "robot/head/command_head_nod";
+const std::string BAXTER_HEAD_NOD_CMD_TOPIC = "robot/head/command_head_nod";
 
 const std::string BAXTER_LEFT_GRAVITY_TOPIC = "robot/limb/left/gravity_compensation_torques";
 const std::string BAXTER_RIGHT_GRAVITY_TOPIC = "robot/limb/right/gravity_compensation_torques";
@@ -97,7 +78,8 @@ const std::string BAXTER_SIM_STARTED = "robot/sim/started";
 
 const int IMG_LOAD_ON_STARTUP_DELAY = 35;  // Timeout for publishing a single RSDK image on start up
 
-enum nav_light_enum {
+enum nav_light_enum
+{
   left_inner_light,
   right_inner_light,
   torso_left_inner_light,
@@ -112,18 +94,17 @@ std::map<std::string, nav_light_enum> nav_light;
 /**
  * Method to initialize the default values for all the variables, instantiate the publishers and subscribers
  */
-bool baxter_emulator::init() {
+bool baxter_emulator::init()
+{
+  // Default values for the assembly state
+  assembly_state.enabled = false;  // true if enabled
+  assembly_state.stopped = false;  // true if stopped -- e-stop asserted
+  assembly_state.error = false;    // true if a component of the assembly has an error
+  assembly_state.estop_button = baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;  // button status
+  assembly_state.estop_source = baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;       // If stopped is
+  // true, the source of the e-stop.
 
-//Default values for the assembly state
-  assembly_state.enabled = false;             // true if enabled
-  assembly_state.stopped = false;          // true if stopped -- e-stop asserted
-  assembly_state.error = false;  // true if a component of the assembly has an error
-  assembly_state.estop_button =
-      baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;  // button status
-  assembly_state.estop_source =
-      baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;  // If stopped is 										true, the source of the e-stop.
-
-  //Default values for the left and right gripper end effector states
+  // Default values for the left and right gripper end effector states
   left_grip_st.timestamp.sec = 0;
   left_grip_st.timestamp.nsec = 0;
   left_grip_st.id = 131073;
@@ -161,16 +142,19 @@ bool baxter_emulator::init() {
   left_grip_prop.properties = "";
   std::string gripper_type;
   ros::param::param<std::string>("~left_gripper_type", gripper_type, "PASSIVE_GRIPPER");
-  if (gripper_type == "SUCTION_CUP_GRIPPER" ) {
-      left_grip_prop.id = 65537;
-      left_grip_prop.ui_type = 1;
-  } else if (gripper_type == "ELECTRIC_GRIPPER" ) {
-      left_grip_prop.id = 65538;
-      left_grip_prop.ui_type = 2;
-      left_grip_prop.serial_number = "3712199347";
-      left_grip_prop.hardware_rev = "2";
-      left_grip_prop.firmware_rev = "3.0.0 5.5";
-      left_grip_prop.firmware_date = "2014/7/24 18:30:00";
+  if (gripper_type == "SUCTION_CUP_GRIPPER")
+  {
+    left_grip_prop.id = 65537;
+    left_grip_prop.ui_type = 1;
+  }
+  else if (gripper_type == "ELECTRIC_GRIPPER")
+  {
+    left_grip_prop.id = 65538;
+    left_grip_prop.ui_type = 2;
+    left_grip_prop.serial_number = "3712199347";
+    left_grip_prop.hardware_rev = "2";
+    left_grip_prop.firmware_rev = "3.0.0 5.5";
+    left_grip_prop.firmware_date = "2014/7/24 18:30:00";
   }
 
   right_grip_prop = left_grip_prop;  // Sample values recorded on both the grippers to do the spoof
@@ -179,20 +163,25 @@ bool baxter_emulator::init() {
   right_grip_prop.firmware_rev = "";
   right_grip_prop.firmware_date = "";
   ros::param::param<std::string>("~right_gripper_type", gripper_type, "PASSIVE_GRIPPER");
-  if (gripper_type == "SUCTION_CUP_GRIPPER" ) {
-      right_grip_prop.id = 65537;
-      right_grip_prop.ui_type = 1;
-  } else if (gripper_type == "ELECTRIC_GRIPPER" ) {
-      right_grip_prop.id = 65538;
-      right_grip_prop.ui_type = 2;
-      right_grip_prop.serial_number = "3712199347";
-      right_grip_prop.hardware_rev = "2";
-      right_grip_prop.firmware_rev = "3.0.0 5.5";
-      right_grip_prop.firmware_date = "2014/7/24 18:30:00";
-  } else {
-      //Default values for the right gripper properties
-      right_grip_prop.id = 131073;
-      right_grip_prop.ui_type = 3;
+  if (gripper_type == "SUCTION_CUP_GRIPPER")
+  {
+    right_grip_prop.id = 65537;
+    right_grip_prop.ui_type = 1;
+  }
+  else if (gripper_type == "ELECTRIC_GRIPPER")
+  {
+    right_grip_prop.id = 65538;
+    right_grip_prop.ui_type = 2;
+    right_grip_prop.serial_number = "3712199347";
+    right_grip_prop.hardware_rev = "2";
+    right_grip_prop.firmware_rev = "3.0.0 5.5";
+    right_grip_prop.firmware_date = "2014/7/24 18:30:00";
+  }
+  else
+  {
+    // Default values for the right gripper properties
+    right_grip_prop.id = 131073;
+    right_grip_prop.ui_type = 3;
   }
 
   leftIL_nav_light.isInputOnly = false;
@@ -219,118 +208,95 @@ bool baxter_emulator::init() {
 
   isStopped = false;
 
-  left_gravity.header.frame_id="base";
-  right_gravity.header.frame_id="base";
+  left_gravity.header.frame_id = "base";
+  right_gravity.header.frame_id = "base";
 
-// Initialize the map that would be used in the nav_light_cb
-  nav_light["left_inner_light"] =left_inner_light;
-  nav_light["right_inner_light"] =right_inner_light;
-  nav_light["torso_left_inner_light"] =torso_left_inner_light;
-  nav_light["torso_right_inner_light"] =torso_right_inner_light;
-  nav_light["left_outer_light"] =left_outer_light;
-  nav_light["right_outer_light"] =right_outer_light;
-  nav_light["torso_left_outer_light"] =torso_left_outer_light;
-  nav_light["torso_right_outer_light"] =torso_right_outer_light;
+  // Initialize the map that would be used in the nav_light_cb
+  nav_light["left_inner_light"] = left_inner_light;
+  nav_light["right_inner_light"] = right_inner_light;
+  nav_light["torso_left_inner_light"] = torso_left_inner_light;
+  nav_light["torso_right_inner_light"] = torso_right_inner_light;
+  nav_light["left_outer_light"] = left_outer_light;
+  nav_light["right_outer_light"] = right_outer_light;
+  nav_light["torso_left_outer_light"] = torso_left_outer_light;
+  nav_light["torso_right_outer_light"] = torso_right_outer_light;
 
   // Initialize the publishers
-  assembly_state_pub = n.advertise<baxter_core_msgs::AssemblyState>(
-      BAXTER_STATE_TOPIC, 1);
-  left_grip_st_pub = n.advertise<baxter_core_msgs::EndEffectorState>(
-      BAXTER_LEFT_GRIPPER_ST, 1);
-  right_grip_st_pub = n.advertise<baxter_core_msgs::EndEffectorState>(
-      BAXTER_RIGHT_GRIPPER_ST, 1);
-  left_grip_prop_pub = n.advertise<baxter_core_msgs::EndEffectorProperties>(
-      BAXTER_LEFT_GRIPPER_PROP, 1);
-  right_grip_prop_pub = n.advertise<baxter_core_msgs::EndEffectorProperties>(
-      BAXTER_RIGHT_GRIPPER_PROP, 1);
+  assembly_state_pub = n.advertise<baxter_core_msgs::AssemblyState>(BAXTER_STATE_TOPIC, 1);
+  left_grip_st_pub = n.advertise<baxter_core_msgs::EndEffectorState>(BAXTER_LEFT_GRIPPER_ST, 1);
+  right_grip_st_pub = n.advertise<baxter_core_msgs::EndEffectorState>(BAXTER_RIGHT_GRIPPER_ST, 1);
+  left_grip_prop_pub = n.advertise<baxter_core_msgs::EndEffectorProperties>(BAXTER_LEFT_GRIPPER_PROP, 1);
+  right_grip_prop_pub = n.advertise<baxter_core_msgs::EndEffectorProperties>(BAXTER_RIGHT_GRIPPER_PROP, 1);
   left_ir_pub = n.advertise<sensor_msgs::Range>(BAXTER_LEFT_IR_TOPIC, 1);
   right_ir_pub = n.advertise<sensor_msgs::Range>(BAXTER_RIGHT_IR_TOPIC, 1);
-  left_ir_state_pub = n.advertise<baxter_core_msgs::AnalogIOState>(
-      BAXTER_LEFT_IR_STATE_TOPIC, 1);
-  right_ir_state_pub = n.advertise<baxter_core_msgs::AnalogIOState>(
-      BAXTER_RIGHT_IR_STATE_TOPIC, 1);
+  left_ir_state_pub = n.advertise<baxter_core_msgs::AnalogIOState>(BAXTER_LEFT_IR_STATE_TOPIC, 1);
+  right_ir_state_pub = n.advertise<baxter_core_msgs::AnalogIOState>(BAXTER_RIGHT_IR_STATE_TOPIC, 1);
   left_ir_int_pub = n.advertise<std_msgs::UInt32>(BAXTER_LEFT_IR_INT_TOPIC, 1);
-  right_ir_int_pub = n.advertise<std_msgs::UInt32>(BAXTER_RIGHT_IR_INT_TOPIC,
-                                                   1);
+  right_ir_int_pub = n.advertise<std_msgs::UInt32>(BAXTER_RIGHT_IR_INT_TOPIC, 1);
 
-  left_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_LEFTIL_TOPIC, 1);
-  left_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_LEFTOL_TOPIC, 1);
-  torso_left_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_TORSO_LEFTIL_TOPIC, 1);
-  torso_left_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_TORSO_LEFTOL_TOPIC, 1);
+  left_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_LEFTIL_TOPIC, 1);
+  left_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_LEFTOL_TOPIC, 1);
+  torso_left_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_TORSO_LEFTIL_TOPIC, 1);
+  torso_left_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_TORSO_LEFTOL_TOPIC, 1);
 
-  right_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_RIGHTIL_TOPIC, 1);
-  right_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_RIGHTOL_TOPIC, 1);
-  torso_right_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_TORSO_RIGHTIL_TOPIC, 1);
-  torso_right_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(
-      BAXTER_TORSO_RIGHTOL_TOPIC, 1);
+  right_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_RIGHTIL_TOPIC, 1);
+  right_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_RIGHTOL_TOPIC, 1);
+  torso_right_inner_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_TORSO_RIGHTIL_TOPIC, 1);
+  torso_right_outer_light_pub = n.advertise<baxter_core_msgs::DigitalIOState>(BAXTER_TORSO_RIGHTOL_TOPIC, 1);
 
   left_grav_pub = n.advertise<baxter_core_msgs::SEAJointState>(BAXTER_LEFT_GRAVITY_TOPIC, 1);
   right_grav_pub = n.advertise<baxter_core_msgs::SEAJointState>(BAXTER_RIGHT_GRAVITY_TOPIC, 1);
 
-  head_pub = n.advertise<baxter_core_msgs::HeadState>(BAXTER_HEAD_STATE_TOPIC,
-                                                      1);
+  head_pub = n.advertise<baxter_core_msgs::HeadState>(BAXTER_HEAD_STATE_TOPIC, 1);
   // Latched Simulator Started Publisher
   sim_started_pub = n.advertise<std_msgs::Empty>(BAXTER_SIM_STARTED, 1, true);
 
-
   // Initialize the subscribers
-  enable_sub = n.subscribe(BAXTER_ENABLE_TOPIC, 100,
-                           &baxter_emulator::enable_cb, this);
-  stop_sub = n.subscribe(BAXTER_STOP_TOPIC, 100, &baxter_emulator::stop_cb,
-                         this);
-  reset_sub = n.subscribe(BAXTER_RESET_TOPIC, 100, &baxter_emulator::reset_cb,
-                          this);
-  jnt_st = n.subscribe(BAXTER_JOINT_TOPIC, 100, &baxter_emulator::update_jnt_st,
-                     this);
-  left_laser_sub = n.subscribe(BAXTER_LEFT_LASER_TOPIC, 100,
-                               &baxter_emulator::left_laser_cb, this);
-  right_laser_sub = n.subscribe(BAXTER_RIGHT_LASER_TOPIC, 100,
-                                &baxter_emulator::right_laser_cb, this);
-  nav_light_sub = n.subscribe(BAXTER_NAV_LIGHT_TOPIC, 100,
-                              &baxter_emulator::nav_light_cb, this);
-  head_nod_sub = n.subscribe(BAXTER_HEAD_NOD_CMD_TOPIC, 100,
-                             &baxter_emulator::head_nod_cb, this);
-  head_nod_timer = n.createTimer(ros::Duration(1),
-                                 &baxter_emulator::reset_head_nod, this, true,
-                                 false);
+  enable_sub = n.subscribe(BAXTER_ENABLE_TOPIC, 100, &baxter_emulator::enable_cb, this);
+  stop_sub = n.subscribe(BAXTER_STOP_TOPIC, 100, &baxter_emulator::stop_cb, this);
+  reset_sub = n.subscribe(BAXTER_RESET_TOPIC, 100, &baxter_emulator::reset_cb, this);
+  jnt_st = n.subscribe(BAXTER_JOINT_TOPIC, 100, &baxter_emulator::update_jnt_st, this);
+  left_laser_sub = n.subscribe(BAXTER_LEFT_LASER_TOPIC, 100, &baxter_emulator::left_laser_cb, this);
+  right_laser_sub = n.subscribe(BAXTER_RIGHT_LASER_TOPIC, 100, &baxter_emulator::right_laser_cb, this);
+  nav_light_sub = n.subscribe(BAXTER_NAV_LIGHT_TOPIC, 100, &baxter_emulator::nav_light_cb, this);
+  head_nod_sub = n.subscribe(BAXTER_HEAD_NOD_CMD_TOPIC, 100, &baxter_emulator::head_nod_cb, this);
+  head_nod_timer = n.createTimer(ros::Duration(1), &baxter_emulator::reset_head_nod, this, true, false);
 }
 
 /**
  * Method that publishes the emulated interfaces' states and data at 100 Hz
  * @param img_path that refers the path of the image that loads on start up
  */
-void baxter_emulator::publish(const std::string &img_path) {
+void baxter_emulator::publish(const std::string& img_path)
+{
   ros::Rate loop_rate(100);
 
   arm_kinematics::Kinematics kin;
   kin.init_grav();
 
   image_transport::ImageTransport it(n);
-  image_transport::Publisher display_pub = it.advertise(BAXTER_DISPLAY_TOPIC,
-                                                        1);
+  image_transport::Publisher display_pub = it.advertise(BAXTER_DISPLAY_TOPIC, 1);
   // Read OpenCV Mat image and convert it to ROS message
   cv_bridge::CvImagePtr cv_ptr(new cv_bridge::CvImage);
-  try {
+  try
+  {
     cv_ptr->image = cv::imread(img_path, CV_LOAD_IMAGE_UNCHANGED);
-    if (cv_ptr->image.data) {
+    if (cv_ptr->image.data)
+    {
       cv_ptr->encoding = sensor_msgs::image_encodings::BGR8;
       sleep(IMG_LOAD_ON_STARTUP_DELAY);  // Wait for the model to load
       display_pub.publish(cv_ptr->toImageMsg());
     }
-  } catch (std::exception e) {
-    ROS_WARN("Unable to load the Startup picture on Baxter's display screen %s",e.what());
+  }
+  catch (std::exception e)
+  {
+    ROS_WARN("Unable to load the Startup picture on Baxter's display screen %s", e.what());
   }
   ROS_INFO("Simulator is loaded and started successfully");
   std_msgs::Empty started_msg;
   sim_started_pub.publish(started_msg);
-  while (ros::ok()) {
+  while (ros::ok())
+  {
     assembly_state_pub.publish(assembly_state);
     left_grip_st_pub.publish(left_grip_st);
     right_grip_st_pub.publish(right_grip_st);
@@ -359,37 +325,36 @@ void baxter_emulator::publish(const std::string &img_path) {
     ros::spinOnce();
     loop_rate.sleep();
   }
-
 }
 /**
  * Method to enable the robot
  */
-void baxter_emulator::enable_cb(const std_msgs::Bool &msg) {
-  if (msg.data && !isStopped) {
+void baxter_emulator::enable_cb(const std_msgs::Bool& msg)
+{
+  if (msg.data && !isStopped)
+  {
     assembly_state.enabled = true;
   }
 
-  else {
+  else
+  {
     assembly_state.enabled = false;
   }
   assembly_state.stopped = false;
-  assembly_state.estop_button =
-      baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
-  assembly_state.estop_source =
-      baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;
+  assembly_state.estop_button = baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
+  assembly_state.estop_source = baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;
   enable = assembly_state.enabled;
 }
 
 /**
  * Method to stop the robot and capture the source of the stop
  */
-void baxter_emulator::stop_cb(const std_msgs::Empty &msg) {
+void baxter_emulator::stop_cb(const std_msgs::Empty& msg)
+{
   assembly_state.enabled = false;
   assembly_state.stopped = true;
-  assembly_state.estop_button =
-      baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
-  assembly_state.estop_source =
-      baxter_core_msgs::AssemblyState::ESTOP_SOURCE_UNKNOWN;
+  assembly_state.estop_button = baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
+  assembly_state.estop_source = baxter_core_msgs::AssemblyState::ESTOP_SOURCE_UNKNOWN;
   enable = false;
   isStopped = true;
 }
@@ -397,13 +362,12 @@ void baxter_emulator::stop_cb(const std_msgs::Empty &msg) {
 /**
  * Method resets all the values to False and 0s
  */
-void baxter_emulator::reset_cb(const std_msgs::Empty &msg) {
+void baxter_emulator::reset_cb(const std_msgs::Empty& msg)
+{
   assembly_state.enabled = false;
   assembly_state.stopped = false;
-  assembly_state.estop_button =
-      baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
-  assembly_state.estop_source =
-      baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;
+  assembly_state.estop_button = baxter_core_msgs::AssemblyState::ESTOP_BUTTON_UNPRESSED;
+  assembly_state.estop_source = baxter_core_msgs::AssemblyState::ESTOP_SOURCE_NONE;
   assembly_state.error = false;
   enable = false;
   isStopped = false;
@@ -412,7 +376,8 @@ void baxter_emulator::reset_cb(const std_msgs::Empty &msg) {
 /**
  * Method to capture the laser data and pass it as IR data for the left arm
  */
-void baxter_emulator::left_laser_cb(const sensor_msgs::LaserScan &msg) {
+void baxter_emulator::left_laser_cb(const sensor_msgs::LaserScan& msg)
+{
   left_ir.header = msg.header;
   left_ir.min_range = msg.range_min;
   left_ir.max_range = msg.range_max;
@@ -431,7 +396,8 @@ void baxter_emulator::left_laser_cb(const sensor_msgs::LaserScan &msg) {
 /**
  * Method to capture the laser data and pass it as IR data for the right arm
  */
-void baxter_emulator::right_laser_cb(const sensor_msgs::LaserScan &msg) {
+void baxter_emulator::right_laser_cb(const sensor_msgs::LaserScan& msg)
+{
   right_ir.header = msg.header;
   right_ir.min_range = msg.range_min;
   right_ir.max_range = msg.range_max;
@@ -447,14 +413,15 @@ void baxter_emulator::right_laser_cb(const sensor_msgs::LaserScan &msg) {
   right_ir_int.data = right_ir.range;
 }
 
-void baxter_emulator::nav_light_cb(
-    const baxter_core_msgs::DigitalOutputCommand &msg) {
+void baxter_emulator::nav_light_cb(const baxter_core_msgs::DigitalOutputCommand& msg)
+{
   int res;
   if (msg.value)
     res = baxter_core_msgs::DigitalIOState::ON;
   else
     res = baxter_core_msgs::DigitalIOState::OFF;
-  switch (nav_light.find(msg.name)->second) {
+  switch (nav_light.find(msg.name)->second)
+  {
     case left_inner_light:
       leftIL_nav_light.state = res;
       break;
@@ -485,65 +452,79 @@ void baxter_emulator::nav_light_cb(
   }
 }
 
-void baxter_emulator::head_nod_cb(const std_msgs::Bool &msg) {
-  if (msg.data) {
+void baxter_emulator::head_nod_cb(const std_msgs::Bool& msg)
+{
+  if (msg.data)
+  {
     head_msg.isNodding = true;
-    if (!head_nod_timer.hasPending()) {
+    if (!head_nod_timer.hasPending())
+    {
       head_nod_timer.setPeriod(ros::Duration(1));
       head_nod_timer.start();
     }
   }
 }
 
-void baxter_emulator::reset_head_nod(const ros::TimerEvent &t) {
+void baxter_emulator::reset_head_nod(const ros::TimerEvent& t)
+{
   head_msg.isNodding = false;
 }
 
-void baxter_emulator::update_jnt_st(const sensor_msgs::JointState &msg) {
+void baxter_emulator::update_jnt_st(const sensor_msgs::JointState& msg)
+{
   jstate_msg = msg;
   float threshold = 0.0009;
-left_gravity.actual_position.resize(left_gravity.name.size());
-left_gravity.actual_velocity.resize(left_gravity.name.size());
-left_gravity.actual_effort.resize(left_gravity.name.size());
-right_gravity.actual_position.resize(left_gravity.name.size());
-right_gravity.actual_velocity.resize(left_gravity.name.size());
-right_gravity.actual_effort.resize(left_gravity.name.size());
-  for (int i = 0; i < msg.name.size(); i++) {
-    if (msg.name[i] == "head_pan") {
+  left_gravity.actual_position.resize(left_gravity.name.size());
+  left_gravity.actual_velocity.resize(left_gravity.name.size());
+  left_gravity.actual_effort.resize(left_gravity.name.size());
+  right_gravity.actual_position.resize(left_gravity.name.size());
+  right_gravity.actual_velocity.resize(left_gravity.name.size());
+  right_gravity.actual_effort.resize(left_gravity.name.size());
+  for (int i = 0; i < msg.name.size(); i++)
+  {
+    if (msg.name[i] == "head_pan")
+    {
       if (fabs(float(head_msg.pan) - float(msg.position[i])) > threshold)
         head_msg.isTurning = true;
       else
         head_msg.isTurning = false;
       head_msg.pan = msg.position[i];
     }
-    else if (msg.name[i] == "l_gripper_l_finger_joint") {
-        left_grip_st.position = (msg.position[i]/0.020833)*100;
+    else if (msg.name[i] == "l_gripper_l_finger_joint")
+    {
+      left_grip_st.position = (msg.position[i] / 0.020833) * 100;
     }
-    else if (msg.name[i] == "r_gripper_l_finger_joint") {
-        right_grip_st.position = (msg.position[i]/0.020833)*100;
+    else if (msg.name[i] == "r_gripper_l_finger_joint")
+    {
+      right_grip_st.position = (msg.position[i] / 0.020833) * 100;
     }
-	else {
-	   for (int j=0;j<left_gravity.name.size();j++) {
-	     if (msg.name[i] == left_gravity.name[j]) {
-	       left_gravity.actual_position[j] = msg.position[i];
-	       left_gravity.actual_velocity[j] = msg.velocity[i];
-	       left_gravity.actual_effort[j] = msg.effort[i];
-	       break;
-	     }
-	     else if(msg.name[i] == right_gravity.name[j]) {
-	       right_gravity.actual_position[j] = msg.position[i];
-	       right_gravity.actual_velocity[j] = msg.velocity[i];
-	       right_gravity.actual_effort[j] = msg.effort[i];
-	       break;
-	      }
-	   }
-	}
+    else
+    {
+      for (int j = 0; j < left_gravity.name.size(); j++)
+      {
+        if (msg.name[i] == left_gravity.name[j])
+        {
+          left_gravity.actual_position[j] = msg.position[i];
+          left_gravity.actual_velocity[j] = msg.velocity[i];
+          left_gravity.actual_effort[j] = msg.effort[i];
+          break;
+        }
+        else if (msg.name[i] == right_gravity.name[j])
+        {
+          right_gravity.actual_position[j] = msg.position[i];
+          right_gravity.actual_velocity[j] = msg.velocity[i];
+          right_gravity.actual_effort[j] = msg.effort[i];
+          break;
+        }
+      }
+    }
   }
 }
 
-}  //namespace
+}  // namespace
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[])
+{
   ros::init(argc, argv, "baxter_emulator");
 
   std::string img_path = argc > 1 ? argv[1] : "";

--- a/baxter_sim_io/include/baxter_sim_io/baxter_io.hpp
+++ b/baxter_sim_io/include/baxter_sim_io/baxter_io.hpp
@@ -41,19 +41,20 @@
 #include "ui_baxter_io.h"
 #include "qnode.hpp"
 
-namespace baxter_sim_io {
+namespace baxter_sim_io
+{
+class BaxterIO : public QMainWindow
+{
+  Q_OBJECT
 
-class BaxterIO : public QMainWindow {
-Q_OBJECT
-
- public:
-  BaxterIO(int argc, char** argv, QWidget *parent = 0);
+public:
+  BaxterIO(int argc, char** argv, QWidget* parent = 0);
   ~BaxterIO();
 
 private:
-    void setstyle(std::string ,std::string , QPushButton&);
+  void setstyle(std::string, std::string, QPushButton&);
 
- private Q_SLOTS:
+private Q_SLOTS:
   void on_left_arm_ok_pressed();
   void on_left_arm_ok_released();
   void on_left_arm_cancel_pressed();
@@ -95,11 +96,11 @@ private:
   void on_right_cuff_grasp_pressed();
   void on_right_cuff_grasp_released();
 
- private:
-  Ui::BaxterIO *ui;
+private:
+  Ui::BaxterIO* ui;
   QNode qnode;
 };
 
 }  // namespace baxter_sim_io
 
-#endif // BAXTER_SIM_IO_BAXTER_IO_H
+#endif  // BAXTER_SIM_IO_BAXTER_IO_H

--- a/baxter_sim_io/include/baxter_sim_io/qnode.hpp
+++ b/baxter_sim_io/include/baxter_sim_io/qnode.hpp
@@ -41,43 +41,38 @@
 #include <baxter_core_msgs/NavigatorState.h>
 #include <baxter_core_msgs/DigitalIOState.h>
 
-namespace baxter_sim_io {
-
-class QNode : public QThread {
-Q_OBJECT
- public:
+namespace baxter_sim_io
+{
+class QNode : public QThread
+{
+  Q_OBJECT
+public:
   QNode(int argc, char** argv);
   virtual ~QNode();
   bool init();
   void run();
-  static baxter_core_msgs::NavigatorState left_arm_nav, right_arm_nav,
-      left_shoulder_nav, right_shoulder_nav;
-  static baxter_core_msgs::DigitalIOState left_cuff_squeeze, right_cuff_squeeze,
-      left_cuff_ok, right_cuff_ok, left_cuff_grasp, right_cuff_grasp,
-      left_shoulder, right_shoulder;
+  static baxter_core_msgs::NavigatorState left_arm_nav, right_arm_nav, left_shoulder_nav, right_shoulder_nav;
+  static baxter_core_msgs::DigitalIOState left_cuff_squeeze, right_cuff_squeeze, left_cuff_ok, right_cuff_ok,
+      left_cuff_grasp, right_cuff_grasp, left_shoulder, right_shoulder;
 
   void rosShutdown();
 
- private:
+private:
   int init_argc;
   char** init_argv;
-  ros::Publisher left_navigator, right_navigator, torso_left_navigator, torso_right_navigator,
-      left_lower_cuff, right_lower_cuff, left_lower_button, right_lower_button,
-      left_upper_button, right_upper_button, left_shoulder_button,
-      right_shoulder_button;
-  ros::Subscriber left_inner_light_sub, left_outer_light_sub,
-                  right_inner_light_sub, right_outer_light_sub,
-                  torso_left_inner_light_sub, torso_left_outer_light_sub,
-                  torso_right_inner_light_sub, torso_right_outer_light_sub;
-  void left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void torso_left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void torso_left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void torso_right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-  void torso_right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg);
-
+  ros::Publisher left_navigator, right_navigator, torso_left_navigator, torso_right_navigator, left_lower_cuff,
+      right_lower_cuff, left_lower_button, right_lower_button, left_upper_button, right_upper_button,
+      left_shoulder_button, right_shoulder_button;
+  ros::Subscriber left_inner_light_sub, left_outer_light_sub, right_inner_light_sub, right_outer_light_sub,
+      torso_left_inner_light_sub, torso_left_outer_light_sub, torso_right_inner_light_sub, torso_right_outer_light_sub;
+  void left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void torso_left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void torso_left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void torso_right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
+  void torso_right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg);
 };
 
 }  // namespace baxter_sim_io

--- a/baxter_sim_io/src/baxter_io.cpp
+++ b/baxter_sim_io/src/baxter_io.cpp
@@ -37,232 +37,273 @@
 #include <iostream>
 #include <baxter_sim_io/baxter_io.hpp>
 
-namespace baxter_sim_io {
-
+namespace baxter_sim_io
+{
 using namespace Qt;
 
 void BaxterIO::setstyle(std::string pressed, std::string released, QPushButton& button)
 {
-
-    QPixmap pix(QString::fromUtf8(released.c_str()));
-    button.setMask(pix.mask());
-    button.setStyleSheet("QPushButton{background-image: url("+QString::fromUtf8(released.c_str())+");\n"
-                                           "background-position: center;\n"
-                                           "background-color: transparent;\n"
-                                           "background-repeat: none;\n"
-                                           "border: none;}\n"
-                                           "QPushButton:pressed{background-image: url("+QString::fromUtf8(pressed.c_str())+");}");
+  QPixmap pix(QString::fromUtf8(released.c_str()));
+  button.setMask(pix.mask());
+  button.setStyleSheet("QPushButton{background-image: url(" + QString::fromUtf8(released.c_str()) +
+                       ");\n"
+                       "background-position: center;\n"
+                       "background-color: transparent;\n"
+                       "background-repeat: none;\n"
+                       "border: none;}\n"
+                       "QPushButton:pressed{background-image: url(" +
+                       QString::fromUtf8(pressed.c_str()) + ");}");
 }
 
-BaxterIO::BaxterIO(int argc, char** argv, QWidget *parent)
-    : QMainWindow(parent),
-      qnode(argc, argv),
-      ui(new Ui::BaxterIO) {
-    ui->setupUi(this);  // Calling this incidentally connects all ui's triggers to on_...() callbacks in this class.
+BaxterIO::BaxterIO(int argc, char** argv, QWidget* parent)
+  : QMainWindow(parent), qnode(argc, argv), ui(new Ui::BaxterIO)
+{
+  ui->setupUi(this);  // Calling this incidentally connects all ui's triggers to on_...() callbacks in this class.
 
-    std::string cancel_r=":/new/prefix/nav_cancel_r.png";
-    std::string cancel_p=":/new/prefix/nav_cancel_p.png";
-    std::string ok_r=":/new/prefix/nav_ok_r.png";
-    std::string ok_p=":/new/prefix/nav_ok_p.png";
-    std::string show_r=":/new/prefix/nav_show_r.png";
-    std::string show_p=":/new/prefix/nav_show_p.png";
+  std::string cancel_r = ":/new/prefix/nav_cancel_r.png";
+  std::string cancel_p = ":/new/prefix/nav_cancel_p.png";
+  std::string ok_r = ":/new/prefix/nav_ok_r.png";
+  std::string ok_p = ":/new/prefix/nav_ok_p.png";
+  std::string show_r = ":/new/prefix/nav_show_r.png";
+  std::string show_p = ":/new/prefix/nav_show_p.png";
 
-    std::string cuff_grasp_r=":/new/prefix/cuff_grasp_r.png";
-    std::string cuff_grasp_p=":/new/prefix/cuff_grasp_p.png";
-    std::string cuff_ok_r=":/new/prefix/cuff_ok_r.png";
-    std::string cuff_ok_p=":/new/prefix/cuff_ok_p.png";
-    std::string cuff_squeeze_r=":/new/prefix/cuff_squeeze_r.png";
-    std::string cuff_squeeze_p=":/new/prefix/cuff_squeeze_p.png";
+  std::string cuff_grasp_r = ":/new/prefix/cuff_grasp_r.png";
+  std::string cuff_grasp_p = ":/new/prefix/cuff_grasp_p.png";
+  std::string cuff_ok_r = ":/new/prefix/cuff_ok_r.png";
+  std::string cuff_ok_p = ":/new/prefix/cuff_ok_p.png";
+  std::string cuff_squeeze_r = ":/new/prefix/cuff_squeeze_r.png";
+  std::string cuff_squeeze_p = ":/new/prefix/cuff_squeeze_p.png";
 
-    //Configure the stylesheet for all the Qwidgets
-    //left arm
-    setstyle(cancel_p,cancel_r,*(ui->left_arm_cancel));
-    setstyle(ok_p,ok_r,*(ui->left_arm_ok));
-    setstyle(show_p,show_r,*(ui->left_arm_show));
-    //left shoulder
-    setstyle(cancel_p,cancel_r,*(ui->left_shoulder_cancel));
-    setstyle(ok_p,ok_r,*(ui->left_shoulder_ok));
-    setstyle(show_p,show_r,*(ui->left_shoulder_show));
-    //left cuff
-    setstyle(cuff_grasp_p,cuff_grasp_r,*(ui->left_cuff_grasp));
-    setstyle(cuff_ok_p,cuff_ok_r,*(ui->left_cuff_ok));
-    setstyle(cuff_squeeze_p,cuff_squeeze_r,*(ui->left_cuff_squeeze));
+  // Configure the stylesheet for all the Qwidgets
+  // left arm
+  setstyle(cancel_p, cancel_r, *(ui->left_arm_cancel));
+  setstyle(ok_p, ok_r, *(ui->left_arm_ok));
+  setstyle(show_p, show_r, *(ui->left_arm_show));
+  // left shoulder
+  setstyle(cancel_p, cancel_r, *(ui->left_shoulder_cancel));
+  setstyle(ok_p, ok_r, *(ui->left_shoulder_ok));
+  setstyle(show_p, show_r, *(ui->left_shoulder_show));
+  // left cuff
+  setstyle(cuff_grasp_p, cuff_grasp_r, *(ui->left_cuff_grasp));
+  setstyle(cuff_ok_p, cuff_ok_r, *(ui->left_cuff_ok));
+  setstyle(cuff_squeeze_p, cuff_squeeze_r, *(ui->left_cuff_squeeze));
 
-    //right arm
-    setstyle(cancel_p,cancel_r,*(ui->right_arm_cancel));
-    setstyle(ok_p,ok_r,*(ui->right_arm_ok));
-    setstyle(show_p,show_r,*(ui->right_arm_show));
-    //right shoulder
-    setstyle(cancel_p,cancel_r,*(ui->right_shoulder_cancel));
-    setstyle(ok_p,ok_r,*(ui->right_shoulder_ok));
-    setstyle(show_p,show_r,*(ui->right_shoulder_show));
-    //right cuff
-    setstyle(cuff_grasp_p,cuff_grasp_r,*(ui->right_cuff_grasp));
-    setstyle(cuff_ok_p,cuff_ok_r,*(ui->right_cuff_ok));
-    setstyle(cuff_squeeze_p,cuff_squeeze_r,*(ui->right_cuff_squeeze));
+  // right arm
+  setstyle(cancel_p, cancel_r, *(ui->right_arm_cancel));
+  setstyle(ok_p, ok_r, *(ui->right_arm_ok));
+  setstyle(show_p, show_r, *(ui->right_arm_show));
+  // right shoulder
+  setstyle(cancel_p, cancel_r, *(ui->right_shoulder_cancel));
+  setstyle(ok_p, ok_r, *(ui->right_shoulder_ok));
+  setstyle(show_p, show_r, *(ui->right_shoulder_show));
+  // right cuff
+  setstyle(cuff_grasp_p, cuff_grasp_r, *(ui->right_cuff_grasp));
+  setstyle(cuff_ok_p, cuff_ok_r, *(ui->right_cuff_ok));
+  setstyle(cuff_squeeze_p, cuff_squeeze_r, *(ui->right_cuff_squeeze));
 }
 
-BaxterIO::~BaxterIO() {
+BaxterIO::~BaxterIO()
+{
   delete ui;
 }
 
-void BaxterIO::on_left_arm_ok_pressed() {
+void BaxterIO::on_left_arm_ok_pressed()
+{
   QNode::left_arm_nav.buttons[0] = true;
 }
 
-void BaxterIO::on_left_arm_ok_released() {
+void BaxterIO::on_left_arm_ok_released()
+{
   QNode::left_arm_nav.buttons[0] = false;
 }
 
-void BaxterIO::on_left_arm_cancel_pressed() {
+void BaxterIO::on_left_arm_cancel_pressed()
+{
   QNode::left_arm_nav.buttons[1] = true;
 }
 
-void BaxterIO::on_left_arm_cancel_released() {
+void BaxterIO::on_left_arm_cancel_released()
+{
   QNode::left_arm_nav.buttons[1] = false;
 }
 
-void BaxterIO::on_left_arm_dial_sliderMoved(int position) {
+void BaxterIO::on_left_arm_dial_sliderMoved(int position)
+{
   QNode::left_arm_nav.wheel = position;
 }
 
-void BaxterIO::on_left_arm_show_pressed() {
+void BaxterIO::on_left_arm_show_pressed()
+{
   QNode::left_arm_nav.buttons[2] = true;
 }
 
-void BaxterIO::on_left_arm_show_released() {
+void BaxterIO::on_left_arm_show_released()
+{
   QNode::left_arm_nav.buttons[2] = false;
 }
 
-void BaxterIO::on_left_cuff_squeeze_pressed() {
+void BaxterIO::on_left_cuff_squeeze_pressed()
+{
   QNode::left_cuff_squeeze.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_left_cuff_squeeze_released() {
+void BaxterIO::on_left_cuff_squeeze_released()
+{
   QNode::left_cuff_squeeze.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 
-void BaxterIO::on_left_cuff_ok_pressed() {
+void BaxterIO::on_left_cuff_ok_pressed()
+{
   QNode::left_cuff_ok.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_left_cuff_ok_released() {
+void BaxterIO::on_left_cuff_ok_released()
+{
   QNode::left_cuff_ok.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 
-void BaxterIO::on_left_cuff_grasp_pressed() {
+void BaxterIO::on_left_cuff_grasp_pressed()
+{
   QNode::left_cuff_grasp.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_left_cuff_grasp_released() {
+void BaxterIO::on_left_cuff_grasp_released()
+{
   QNode::left_cuff_grasp.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 
-void BaxterIO::on_left_shoulder_ok_pressed() {
+void BaxterIO::on_left_shoulder_ok_pressed()
+{
   QNode::left_shoulder_nav.buttons[0] = true;
 }
 
-void BaxterIO::on_left_shoulder_ok_released() {
+void BaxterIO::on_left_shoulder_ok_released()
+{
   QNode::left_shoulder_nav.buttons[0] = false;
 }
 
-void BaxterIO::on_left_shoulder_cancel_pressed() {
+void BaxterIO::on_left_shoulder_cancel_pressed()
+{
   QNode::left_shoulder_nav.buttons[1] = true;
 }
 
-void BaxterIO::on_left_shoulder_cancel_released() {
+void BaxterIO::on_left_shoulder_cancel_released()
+{
   QNode::left_shoulder_nav.buttons[1] = false;
 }
 
-void BaxterIO::on_left_shoulder_show_pressed() {
+void BaxterIO::on_left_shoulder_show_pressed()
+{
   QNode::left_shoulder_nav.buttons[2] = true;
 }
 
-void BaxterIO::on_left_shoulder_show_released() {
+void BaxterIO::on_left_shoulder_show_released()
+{
   QNode::left_shoulder_nav.buttons[2] = false;
 }
 
-void BaxterIO::on_left_shoulder_dial_sliderMoved(int position) {
+void BaxterIO::on_left_shoulder_dial_sliderMoved(int position)
+{
   QNode::left_shoulder_nav.wheel = position;
 }
 
-void BaxterIO::on_right_shoulder_ok_pressed() {
+void BaxterIO::on_right_shoulder_ok_pressed()
+{
   QNode::right_shoulder_nav.buttons[0] = true;
 }
 
-void BaxterIO::on_right_shoulder_ok_released() {
+void BaxterIO::on_right_shoulder_ok_released()
+{
   QNode::right_shoulder_nav.buttons[0] = false;
 }
 
-void BaxterIO::on_right_shoulder_cancel_pressed() {
+void BaxterIO::on_right_shoulder_cancel_pressed()
+{
   QNode::right_shoulder_nav.buttons[1] = true;
 }
 
-void BaxterIO::on_right_shoulder_cancel_released() {
+void BaxterIO::on_right_shoulder_cancel_released()
+{
   QNode::right_shoulder_nav.buttons[1] = false;
 }
 
-void BaxterIO::on_right_shoulder_dial_sliderMoved(int position) {
+void BaxterIO::on_right_shoulder_dial_sliderMoved(int position)
+{
   QNode::right_shoulder_nav.wheel = position;
 }
 
-void BaxterIO::on_right_shoulder_show_pressed() {
+void BaxterIO::on_right_shoulder_show_pressed()
+{
   QNode::right_shoulder_nav.buttons[2] = true;
 }
 
-void BaxterIO::on_right_shoulder_show_released() {
+void BaxterIO::on_right_shoulder_show_released()
+{
   QNode::right_shoulder_nav.buttons[2] = false;
 }
 
-void BaxterIO::on_right_arm_ok_pressed() {
+void BaxterIO::on_right_arm_ok_pressed()
+{
   QNode::right_arm_nav.buttons[0] = true;
 }
 
-void BaxterIO::on_right_arm_ok_released() {
+void BaxterIO::on_right_arm_ok_released()
+{
   QNode::right_arm_nav.buttons[0] = false;
 }
 
-void BaxterIO::on_right_arm_cancel_pressed() {
+void BaxterIO::on_right_arm_cancel_pressed()
+{
   QNode::right_arm_nav.buttons[1] = true;
 }
 
-void BaxterIO::on_right_arm_cancel_released() {
+void BaxterIO::on_right_arm_cancel_released()
+{
   QNode::right_arm_nav.buttons[1] = false;
 }
 
-void BaxterIO::on_right_arm_dial_sliderMoved(int position) {
+void BaxterIO::on_right_arm_dial_sliderMoved(int position)
+{
   QNode::right_arm_nav.wheel = position;
 }
 
-void BaxterIO::on_right_arm_show_pressed() {
+void BaxterIO::on_right_arm_show_pressed()
+{
   QNode::right_arm_nav.buttons[2] = true;
 }
 
-void BaxterIO::on_right_arm_show_released() {
+void BaxterIO::on_right_arm_show_released()
+{
   QNode::right_arm_nav.buttons[2] = false;
 }
 
-void BaxterIO::on_right_cuff_squeeze_pressed() {
+void BaxterIO::on_right_cuff_squeeze_pressed()
+{
   QNode::right_cuff_squeeze.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_right_cuff_squeeze_released() {
+void BaxterIO::on_right_cuff_squeeze_released()
+{
   QNode::right_cuff_squeeze.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 
-void BaxterIO::on_right_cuff_ok_pressed() {
+void BaxterIO::on_right_cuff_ok_pressed()
+{
   QNode::right_cuff_ok.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_right_cuff_ok_released() {
+void BaxterIO::on_right_cuff_ok_released()
+{
   QNode::right_cuff_ok.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 
-void BaxterIO::on_right_cuff_grasp_pressed() {
+void BaxterIO::on_right_cuff_grasp_pressed()
+{
   QNode::right_cuff_grasp.state = baxter_core_msgs::DigitalIOState::PRESSED;
 }
 
-void BaxterIO::on_right_cuff_grasp_released() {
+void BaxterIO::on_right_cuff_grasp_released()
+{
   QNode::right_cuff_grasp.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
 }
 

--- a/baxter_sim_io/src/main.cpp
+++ b/baxter_sim_io/src/main.cpp
@@ -37,34 +37,35 @@
 #include <signal.h>
 #include <sys/types.h>
 
-void signalhandler(int sig) {
-  if (sig == SIGINT) {
+void signalhandler(int sig)
+{
+  if (sig == SIGINT)
+  {
     qApp->quit();
   }
-  else if (sig == SIGTERM) {
+  else if (sig == SIGTERM)
+  {
     qApp->quit();
   }
 }
 
-int main(int argc, char **argv) {
+int main(int argc, char** argv)
+{
+  QApplication app(argc, argv);
+  baxter_sim_io::BaxterIO w(argc, argv);
+  // Register Signal handler for ctrl+c
+  signal(SIGINT, signalhandler);
+  signal(SIGTERM, signalhandler);
+  w.show();
+  app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
 
-    QApplication app(argc, argv);
-    baxter_sim_io::BaxterIO w(argc,argv);
-    //Register Signal handler for ctrl+c
-    signal(SIGINT,signalhandler);
-    signal(SIGTERM,signalhandler);
-    w.show();
-    app.connect(&app, SIGNAL(lastWindowClosed()), &app, SLOT(quit()));
-
-    int result = app.exec();
-	return result;
+  int result = app.exec();
+  return result;
 }
 
-    baxter_core_msgs::NavigatorState baxter_sim_io::QNode::left_arm_nav, baxter_sim_io::QNode::right_arm_nav,
-	baxter_sim_io::QNode::left_shoulder_nav, baxter_sim_io::QNode::right_shoulder_nav;
+baxter_core_msgs::NavigatorState baxter_sim_io::QNode::left_arm_nav, baxter_sim_io::QNode::right_arm_nav,
+    baxter_sim_io::QNode::left_shoulder_nav, baxter_sim_io::QNode::right_shoulder_nav;
 
-    baxter_core_msgs::DigitalIOState baxter_sim_io::QNode::left_cuff_squeeze,
-	baxter_sim_io::QNode::right_cuff_squeeze, baxter_sim_io::QNode::left_cuff_ok,
-	baxter_sim_io::QNode::right_cuff_ok, baxter_sim_io::QNode::left_cuff_grasp,
-	baxter_sim_io::QNode::right_cuff_grasp, baxter_sim_io::QNode::left_shoulder,
-	baxter_sim_io::QNode::right_shoulder;
+baxter_core_msgs::DigitalIOState baxter_sim_io::QNode::left_cuff_squeeze, baxter_sim_io::QNode::right_cuff_squeeze,
+    baxter_sim_io::QNode::left_cuff_ok, baxter_sim_io::QNode::right_cuff_ok, baxter_sim_io::QNode::left_cuff_grasp,
+    baxter_sim_io::QNode::right_cuff_grasp, baxter_sim_io::QNode::left_shoulder, baxter_sim_io::QNode::right_shoulder;

--- a/baxter_sim_io/src/qnode.cpp
+++ b/baxter_sim_io/src/qnode.cpp
@@ -39,33 +39,26 @@
 #include <baxter_sim_io/qnode.hpp>
 #include <signal.h>
 
-namespace baxter_sim_io {
+namespace baxter_sim_io
+{
+const std::string BAXTER_LEFTIL_TOPIC = "robot/digital_io/left_inner_light/state";
+const std::string BAXTER_LEFTOL_TOPIC = "robot/digital_io/left_outer_light/state";
+const std::string BAXTER_TORSO_LEFTIL_TOPIC = "robot/digital_io/torso_left_inner_light/state";
+const std::string BAXTER_TORSO_LEFTOL_TOPIC = "robot/digital_io/torso_left_outer_light/state";
+const std::string BAXTER_RIGHTIL_TOPIC = "robot/digital_io/right_inner_light/state";
+const std::string BAXTER_RIGHTOL_TOPIC = "robot/digital_io/right_outer_light/state";
+const std::string BAXTER_TORSO_RIGHTIL_TOPIC = "robot/digital_io/torso_right_inner_light/state";
+const std::string BAXTER_TORSO_RIGHTOL_TOPIC = "robot/digital_io/torso_right_outer_light/state";
 
-const std::string BAXTER_LEFTIL_TOPIC =
-        "robot/digital_io/left_inner_light/state";
-const std::string BAXTER_LEFTOL_TOPIC =
-        "robot/digital_io/left_outer_light/state";
-const std::string BAXTER_TORSO_LEFTIL_TOPIC =
-        "robot/digital_io/torso_left_inner_light/state";
-const std::string BAXTER_TORSO_LEFTOL_TOPIC =
-        "robot/digital_io/torso_left_outer_light/state";
-const std::string BAXTER_RIGHTIL_TOPIC =
-        "robot/digital_io/right_inner_light/state";
-const std::string BAXTER_RIGHTOL_TOPIC =
-        "robot/digital_io/right_outer_light/state";
-const std::string BAXTER_TORSO_RIGHTIL_TOPIC =
-        "robot/digital_io/torso_right_inner_light/state";
-const std::string BAXTER_TORSO_RIGHTOL_TOPIC =
-        "robot/digital_io/torso_right_outer_light/state";
-
-QNode::QNode(int argc, char** argv)
-    : init_argc(argc),
-      init_argv(argv) {
+QNode::QNode(int argc, char** argv) : init_argc(argc), init_argv(argv)
+{
   init();
 }
 
-QNode::~QNode() {
-  if (ros::isStarted()) {
+QNode::~QNode()
+{
+  if (ros::isStarted())
+  {
     ros::shutdown();  // explicitly needed since we use ros::start();
     ros::waitForShutdown();
   }
@@ -74,45 +67,39 @@ QNode::~QNode() {
 
 void quit(int sig)
 {
-ros::shutdown();
-exit(0);
+  ros::shutdown();
+  exit(0);
 }
 
-bool QNode::init() {
+bool QNode::init()
+{
   ros::init(init_argc, init_argv, "baxter_sim_io");
-  if (!ros::master::check()) {
+  if (!ros::master::check())
+  {
     return false;
   }
   ros::start();  // explicitly needed since our nodehandle is going out of scope.
   ros::NodeHandle n;
 
-  left_navigator = n.advertise<baxter_core_msgs::NavigatorState>(
-      "/robot/navigators/left_navigator/state", 1);
-  right_navigator = n.advertise<baxter_core_msgs::NavigatorState>(
-      "/robot/navigators/right_navigator/state", 1);
-  torso_left_navigator = n.advertise<baxter_core_msgs::NavigatorState>(
-      "/robot/navigators/torso_left_navigator/state", 1);
-  torso_right_navigator = n.advertise<baxter_core_msgs::NavigatorState>(
-      "/robot/navigators/torso_right_navigator/state", 1);
+  left_navigator = n.advertise<baxter_core_msgs::NavigatorState>("/robot/navigators/left_navigator/state", 1);
+  right_navigator = n.advertise<baxter_core_msgs::NavigatorState>("/robot/navigators/right_navigator/state", 1);
+  torso_left_navigator =
+      n.advertise<baxter_core_msgs::NavigatorState>("/robot/navigators/torso_left_navigator/state", 1);
+  torso_right_navigator =
+      n.advertise<baxter_core_msgs::NavigatorState>("/robot/navigators/torso_right_navigator/state", 1);
 
-  left_lower_cuff = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/left_lower_cuff/state", 1);
-  right_lower_cuff = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/right_lower_cuff/state", 1);
+  left_lower_cuff = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/left_lower_cuff/state", 1);
+  right_lower_cuff = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/right_lower_cuff/state", 1);
 
-  left_lower_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/left_lower_button/state", 1);
-  right_lower_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/right_lower_button/state", 1);
+  left_lower_button = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/left_lower_button/state", 1);
+  right_lower_button = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/right_lower_button/state", 1);
 
-  left_upper_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/left_upper_button/state", 1);
-  right_upper_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/right_upper_button/state", 1);
-  left_shoulder_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/left_shoulder_button/state", 1);
-  right_shoulder_button = n.advertise<baxter_core_msgs::DigitalIOState>(
-      "/robot/digital_io/right_shoulder_button/state", 1);
+  left_upper_button = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/left_upper_button/state", 1);
+  right_upper_button = n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/right_upper_button/state", 1);
+  left_shoulder_button =
+      n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/left_shoulder_button/state", 1);
+  right_shoulder_button =
+      n.advertise<baxter_core_msgs::DigitalIOState>("/robot/digital_io/right_shoulder_button/state", 1);
 
   QNode::left_arm_nav.button_names.push_back("ok");
   QNode::left_arm_nav.button_names.push_back("back");
@@ -179,55 +166,58 @@ bool QNode::init() {
   QNode::right_shoulder.state = baxter_core_msgs::DigitalIOState::UNPRESSED;
   QNode::right_shoulder.isInputOnly = true;
 
-  left_inner_light_sub = n.subscribe(BAXTER_LEFTIL_TOPIC, 100,
-                           &QNode::left_inner_light_sub_cb, this);
-  left_outer_light_sub = n.subscribe(BAXTER_LEFTOL_TOPIC, 100,
-                           &QNode::left_outer_light_sub_cb, this);
-  right_inner_light_sub = n.subscribe(BAXTER_RIGHTIL_TOPIC, 100,
-                           &QNode::right_inner_light_sub_cb, this);
-  right_outer_light_sub = n.subscribe(BAXTER_RIGHTOL_TOPIC, 100,
-                           &QNode::right_outer_light_sub_cb, this);
-  torso_left_inner_light_sub = n.subscribe(BAXTER_TORSO_LEFTIL_TOPIC, 100,
-                           &QNode::torso_left_inner_light_sub_cb, this);
-  torso_left_outer_light_sub = n.subscribe(BAXTER_TORSO_LEFTOL_TOPIC, 100,
-                           &QNode::torso_left_outer_light_sub_cb, this);
-  torso_right_inner_light_sub = n.subscribe(BAXTER_TORSO_RIGHTIL_TOPIC, 100,
-                           &QNode::torso_right_inner_light_sub_cb, this);
-  torso_right_outer_light_sub = n.subscribe(BAXTER_TORSO_RIGHTOL_TOPIC, 100,
-                           &QNode::torso_right_outer_light_sub_cb, this);
+  left_inner_light_sub = n.subscribe(BAXTER_LEFTIL_TOPIC, 100, &QNode::left_inner_light_sub_cb, this);
+  left_outer_light_sub = n.subscribe(BAXTER_LEFTOL_TOPIC, 100, &QNode::left_outer_light_sub_cb, this);
+  right_inner_light_sub = n.subscribe(BAXTER_RIGHTIL_TOPIC, 100, &QNode::right_inner_light_sub_cb, this);
+  right_outer_light_sub = n.subscribe(BAXTER_RIGHTOL_TOPIC, 100, &QNode::right_outer_light_sub_cb, this);
+  torso_left_inner_light_sub = n.subscribe(BAXTER_TORSO_LEFTIL_TOPIC, 100, &QNode::torso_left_inner_light_sub_cb, this);
+  torso_left_outer_light_sub = n.subscribe(BAXTER_TORSO_LEFTOL_TOPIC, 100, &QNode::torso_left_outer_light_sub_cb, this);
+  torso_right_inner_light_sub =
+      n.subscribe(BAXTER_TORSO_RIGHTIL_TOPIC, 100, &QNode::torso_right_inner_light_sub_cb, this);
+  torso_right_outer_light_sub =
+      n.subscribe(BAXTER_TORSO_RIGHTOL_TOPIC, 100, &QNode::torso_right_outer_light_sub_cb, this);
   start();
   return true;
 }
 
-void QNode::left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::left_arm_nav.lights[0] = bool(msg.state);
+void QNode::left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::left_arm_nav.lights[0] = bool(msg.state);
 }
-void QNode::left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::left_arm_nav.lights[1] = bool(msg.state);
+void QNode::left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::left_arm_nav.lights[1] = bool(msg.state);
 }
-void QNode::right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::right_arm_nav.lights[0] = bool(msg.state);
+void QNode::right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::right_arm_nav.lights[0] = bool(msg.state);
 }
-void QNode::right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::right_arm_nav.lights[1] = bool(msg.state);
+void QNode::right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::right_arm_nav.lights[1] = bool(msg.state);
 }
-void QNode::torso_left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::left_shoulder_nav.lights[0] = bool(msg.state);
+void QNode::torso_left_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::left_shoulder_nav.lights[0] = bool(msg.state);
 }
-void QNode::torso_left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::left_shoulder_nav.lights[1] = bool(msg.state);
+void QNode::torso_left_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::left_shoulder_nav.lights[1] = bool(msg.state);
 }
-void QNode::torso_right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::right_shoulder_nav.lights[0] = bool(msg.state);
+void QNode::torso_right_inner_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::right_shoulder_nav.lights[0] = bool(msg.state);
 }
-void QNode::torso_right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState &msg){
-    QNode::right_shoulder_nav.lights[1] = bool(msg.state);
+void QNode::torso_right_outer_light_sub_cb(const baxter_core_msgs::DigitalIOState& msg)
+{
+  QNode::right_shoulder_nav.lights[1] = bool(msg.state);
 }
 
-void QNode::run() {
+void QNode::run()
+{
   ros::Rate loop_rate(100);
-  while (ros::ok()) {
-
+  while (ros::ok())
+  {
     left_navigator.publish(QNode::left_arm_nav);
     right_navigator.publish(QNode::right_arm_nav);
     torso_left_navigator.publish(QNode::left_shoulder_nav);

--- a/baxter_sim_kinematics/include/baxter_sim_kinematics/arm_kinematics.h
+++ b/baxter_sim_kinematics/include/baxter_sim_kinematics/arm_kinematics.h
@@ -54,27 +54,31 @@
 #include <gazebo_msgs/GetLinkProperties.h>
 #include <algorithm>
 
-namespace arm_kinematics {
-
-//Structures to pass the messages
-typedef struct INFO {
+namespace arm_kinematics
+{
+// Structures to pass the messages
+typedef struct INFO
+{
   std::vector<std::string> link_names;
   std::vector<std::string> joint_names;
 } KinematicSolverInfo;
 
-class Kinematics {
- public:
+class Kinematics
+{
+public:
   Kinematics();
   bool init_grav();
 
   /* Initializes the solvers and the other variables required
    *  @returns true is successful
    */
-  bool init(std::string tip_name, int &no_jts);
+  bool init(std::string tip_name, int& no_jts);
   typedef boost::shared_ptr<Kinematics> Ptr;
-  static Ptr create(std::string tip_name, int &no_jts) {
+  static Ptr create(std::string tip_name, int& no_jts)
+  {
     Ptr parm_kinematics = Ptr(new Kinematics());
-    if (parm_kinematics->init(tip_name, no_jts)) {
+    if (parm_kinematics->init(tip_name, no_jts))
+    {
       return parm_kinematics;
     }
     return Ptr();
@@ -83,25 +87,25 @@ class Kinematics {
   /* Method to calculate the IK for the required end pose
    *  @returns true if successful
    */
-  bool getPositionIK(const geometry_msgs::PoseStamped &pose_stamp,
-                     const sensor_msgs::JointState &seed,
-                     sensor_msgs::JointState *result);
+  bool getPositionIK(const geometry_msgs::PoseStamped& pose_stamp, const sensor_msgs::JointState& seed,
+                     sensor_msgs::JointState* result);
 
   /* Method to calculate the FK for the required joint configuration
    *  @returns true if successful
    */
-  bool getPositionFK(std::string frame_id,
-                     const sensor_msgs::JointState &joint_configuration,
-                     geometry_msgs::PoseStamped &res);
+  bool getPositionFK(std::string frame_id, const sensor_msgs::JointState& joint_configuration,
+                     geometry_msgs::PoseStamped& res);
 
   /* Method to calculate the torques required to apply at each of the joints for gravity compensation
    *  @returns true is successful
    */
-  //bool getGravityTorques(const sensor_msgs::JointState &joint_configuration,
-  //std::vector<double> &torquesOut);
-  bool getGravityTorques(const sensor_msgs::JointState joint_configuration, baxter_core_msgs::SEAJointState &left_gravity, baxter_core_msgs::SEAJointState &right_gravity, bool isEnabled);
+  // bool getGravityTorques(const sensor_msgs::JointState &joint_configuration,
+  // std::vector<double> &torquesOut);
+  bool getGravityTorques(const sensor_msgs::JointState joint_configuration,
+                         baxter_core_msgs::SEAJointState& left_gravity, baxter_core_msgs::SEAJointState& right_gravity,
+                         bool isEnabled);
 
- private:
+private:
   ros::NodeHandle nh, nh_private;
   std::string root_name, tip_name, grav_left_name, grav_right_name;
   KDL::JntArray joint_min, joint_max;
@@ -109,7 +113,7 @@ class Kinematics {
   unsigned int num_joints;
 
   KDL::ChainFkSolverPos_recursive* fk_solver;
-  KDL::ChainIkSolverPos_NR_JL *ik_solver_pos;
+  KDL::ChainIkSolverPos_NR_JL* ik_solver_pos;
   KDL::ChainIkSolverVel_pinv* ik_solver_vel;
   KDL::ChainIdSolver_RNE *gravity_solver_l, *gravity_solver_r;
 
@@ -129,18 +133,17 @@ class Kinematics {
   /* Method to read the URDF model and extract the joints
    *  @returns true is successful
    */
-  bool readJoints(urdf::Model &robot_model);
+  bool readJoints(urdf::Model& robot_model);
 
   /* Method to calculate the Joint index of a particular joint from the KDL chain
    *  @returns the index of the joint
    */
-  int getJointIndex(const std::string &name);
+  int getJointIndex(const std::string& name);
 
   /* Method to calculate the KDL segment index of a particular segment from the KDL chain
    *  @returns the index of the segment
    */
-  int getKDLSegmentIndex(const std::string &name);
+  int getKDLSegmentIndex(const std::string& name);
 };
-
 }
 #endif

--- a/baxter_sim_kinematics/include/baxter_sim_kinematics/position_kinematics.h
+++ b/baxter_sim_kinematics/include/baxter_sim_kinematics/position_kinematics.h
@@ -46,17 +46,16 @@
 #include <baxter_sim_kinematics/arm_kinematics.h>
 #include <sensor_msgs/JointState.h>
 
-namespace kinematics {
-class position_kinematics {
- protected:
-  position_kinematics() {
-  }
-  ;
+namespace kinematics
+{
+class position_kinematics
+{
+protected:
+  position_kinematics(){};
 
   bool init(std::string side);
 
- public:
-
+public:
   //! return types of create() and createOnStack()
   typedef boost::shared_ptr<position_kinematics> poskin_ptr;
 
@@ -69,9 +68,11 @@ class position_kinematics {
    *
    * @return boost::shared_ptr
    */
-  static poskin_ptr create(std::string side) {
+  static poskin_ptr create(std::string side)
+  {
     poskin_ptr pk_ptr = poskin_ptr(new position_kinematics());
-    if (pk_ptr->init(side)) {
+    if (pk_ptr->init(side))
+    {
       return pk_ptr;
     }
     return poskin_ptr();
@@ -81,14 +82,15 @@ class position_kinematics {
    * Method that serves as the main execution loop of the Node.  This is called in the main() function to 'run'
    * and only returns after exit or ros::shutdown is called.
    */
-  void run() {
-    //just do spin here (blocks until shutdown), remove while loop
+  void run()
+  {
+    // just do spin here (blocks until shutdown), remove while loop
     ros::spin();
 
-    //we have left the ros spin loop, clean up (if needed) then shutdown
+    // we have left the ros spin loop, clean up (if needed) then shutdown
     exit();
 
-    //attempt proper shutdown
+    // attempt proper shutdown
     ros::shutdown();
   }
 
@@ -97,14 +99,15 @@ class position_kinematics {
    * cleanup and manually exit the node's run loop.
    * This is usually triggered by capturing a SIGTERM, etc.
    */
-  void exit() {
-    //Do anything to shut down cleanly
-    //Note: Run loop will call shutdown before exiting
+  void exit()
+  {
+    // Do anything to shut down cleanly
+    // Note: Run loop will call shutdown before exiting
 
     m_ikService.shutdown();
   }
 
- private:
+private:
   /**
    * Callback function that checks and sets the robot enabled flag
    */
@@ -117,13 +120,14 @@ class position_kinematics {
   geometry_msgs::PoseStamped FKCalc(const sensor_msgs::JointState req);
 
   /**
-   * Callback function for the IK service that responds with the appropriate joint configuration or error message if not found
+   * Callback function for the IK service that responds with the appropriate joint configuration or error message if not
+   * found
    */
-  bool IKCallback(baxter_core_msgs::SolvePositionIK::Request &req,
-                  baxter_core_msgs::SolvePositionIK::Response &res);
+  bool IKCallback(baxter_core_msgs::SolvePositionIK::Request& req, baxter_core_msgs::SolvePositionIK::Response& res);
 
   /**
-   * Callback function for the FK subscriber that retrievs the appropriate FK from the Joint states and publishes it to the endpoint
+   * Callback function for the FK subscriber that retrievs the appropriate FK from the Joint states and publishes it to
+   * the endpoint
    * topic
    */
   void FKCallback(const sensor_msgs::JointState msg);
@@ -131,8 +135,7 @@ class position_kinematics {
   /**
    * Method to Filter the names and positions of the initialized side from the remaining
    */
-  void FilterJointState(const sensor_msgs::JointState *msg,
-                        sensor_msgs::JointState &res);
+  void FilterJointState(const sensor_msgs::JointState* msg, sensor_msgs::JointState& res);
 
   bool is_enabled;
   std::string m_limbName;
@@ -145,9 +148,7 @@ class position_kinematics {
   std::string tip_name;
   std::vector<std::string> joint_names;
   int no_jts;
-
 };
-
 }
 
 #endif /* POSITION_KINEMATICS_H_ */

--- a/baxter_sim_kinematics/src/arm_kinematics.cpp
+++ b/baxter_sim_kinematics/src/arm_kinematics.cpp
@@ -35,57 +35,61 @@
 #include <ros/ros.h>
 #include <baxter_sim_kinematics/arm_kinematics.h>
 
-namespace arm_kinematics {
-
-Kinematics::Kinematics()
-    : nh_private("~") {
+namespace arm_kinematics
+{
+Kinematics::Kinematics() : nh_private("~")
+{
 }
 
-bool Kinematics::init_grav() {
-
+bool Kinematics::init_grav()
+{
   std::string urdf_xml, full_urdf_xml;
   nh.param("urdf_xml", urdf_xml, std::string("robot_description"));
   nh.searchParam(urdf_xml, full_urdf_xml);
   ROS_DEBUG_NAMED("arm_kinematics", "Reading xml file from parameter server");
   std::string result;
-  if (!nh.getParam(full_urdf_xml, result)) {
-    ROS_FATAL_NAMED("arm_kinematics", "Could not load the xml from parameter server: %s",
-              urdf_xml.c_str());
+  if (!nh.getParam(full_urdf_xml, result))
+  {
+    ROS_FATAL_NAMED("arm_kinematics", "Could not load the xml from parameter server: %s", urdf_xml.c_str());
     return false;
   }
 
-  if (!nh.getParam("root_name", root_name)) {
+  if (!nh.getParam("root_name", root_name))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "GenericIK: No tip name for gravity found on parameter server");
     return false;
   }
-  if (!nh.getParam("grav_right_name", grav_right_name)) {
+  if (!nh.getParam("grav_right_name", grav_right_name))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "GenericIK: No tip name for gravity found on parameter server");
     return false;
   }
-  if (!nh.getParam("grav_left_name", grav_left_name)) {
+  if (!nh.getParam("grav_left_name", grav_left_name))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "GenericIK: No tip name for gravity found on parameter server");
     return false;
   }
 
-  //Service client to set the gravity false for the limbs
+  // Service client to set the gravity false for the limbs
   ros::ServiceClient get_lp_client = nh.serviceClient<gazebo_msgs::GetLinkProperties>("/gazebo/get_link_properties");
 
-  //Wait for service to become available
+  // Wait for service to become available
   get_lp_client.waitForExistence();
 
-  //Service client to set the gravity false for the limbs
+  // Service client to set the gravity false for the limbs
   ros::ServiceClient set_lp_client = nh.serviceClient<gazebo_msgs::SetLinkProperties>("/gazebo/set_link_properties");
 
-  //Wait for service to become availablestd::find(vector.begin(), vector.end(), item)!=vector.end()
+  // Wait for service to become availablestd::find(vector.begin(), vector.end(), item)!=vector.end()
   set_lp_client.waitForExistence();
 
   gazebo_msgs::SetLinkProperties setlinkproperties;
   gazebo_msgs::GetLinkProperties getlinkproperties;
 
-  setlinkproperties.request.gravity_mode=0;
-  //Load the right chain and copy them to Right specific variables
+  setlinkproperties.request.gravity_mode = 0;
+  // Load the right chain and copy them to Right specific variables
   tip_name = grav_right_name;
-  if (!loadModel(result)) {
+  if (!loadModel(result))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "Could not load models!");
     return false;
   }
@@ -94,19 +98,23 @@ bool Kinematics::init_grav() {
   right_joint.clear();
   right_joint.reserve(chain.getNrOfSegments());
   std::vector<std::string>::iterator idx;
-  //Update the right_joint with the fixed joints from the URDF. Get each of the link's properties from GetLinkProperties service and
-  //call the SetLinkProperties service with the same set of parameters except for the gravity_mode, which would be disabled. This is
-  //to disable the gravity in the links, thereby to eliminate the need for gravity compensation
-  for (int i = 0; i < chain.getNrOfSegments(); i++) {
+  // Update the right_joint with the fixed joints from the URDF. Get each of the link's properties from
+  // GetLinkProperties service and
+  // call the SetLinkProperties service with the same set of parameters except for the gravity_mode, which would be
+  // disabled. This is
+  // to disable the gravity in the links, thereby to eliminate the need for gravity compensation
+  for (int i = 0; i < chain.getNrOfSegments(); i++)
+  {
     std::string seg_name = chain.getSegment(i).getName();
     std::string joint_name = chain.getSegment(i).getJoint().getName();
     idx = std::find(info.joint_names.begin(), info.joint_names.end(), joint_name);
-    if (idx != info.joint_names.end()) {
+    if (idx != info.joint_names.end())
+    {
       right_joint.push_back(*idx);
     }
     std::string link_name = chain.getSegment(i).getName();
-    getlinkproperties.request.link_name=link_name;
-    setlinkproperties.request.link_name=link_name;
+    getlinkproperties.request.link_name = link_name;
+    setlinkproperties.request.link_name = link_name;
     get_lp_client.call(getlinkproperties);
     setlinkproperties.request.com = getlinkproperties.response.com;
     setlinkproperties.request.mass = getlinkproperties.response.mass;
@@ -120,13 +128,13 @@ bool Kinematics::init_grav() {
     set_lp_client.call(setlinkproperties);
   }
 
-  //Create a gravity solver for the right chain
-  gravity_solver_r = new KDL::ChainIdSolver_RNE(grav_chain_r,
-                                                KDL::Vector(0.0, 0.0, -9.8));
+  // Create a gravity solver for the right chain
+  gravity_solver_r = new KDL::ChainIdSolver_RNE(grav_chain_r, KDL::Vector(0.0, 0.0, -9.8));
 
-  //Load the left chain and copy them to Right specific variable
+  // Load the left chain and copy them to Right specific variable
   tip_name = grav_left_name;
-  if (!loadModel(result)) {
+  if (!loadModel(result))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "Could not load models!");
     return false;
   }
@@ -134,20 +142,24 @@ bool Kinematics::init_grav() {
   grav_chain_l = chain;
   left_joint.clear();
   left_joint.reserve(chain.getNrOfSegments());
-  //Update the left_joint with the fixed joints from the URDF. Get each of the link's properties from GetLinkProperties service and
-  //call the SetLinkProperties service with the same set of parameters except for the gravity_mode, which would be disabled. This is
-  //to disable the gravity in the links, thereby to eliminate the need for gravity compensation
-  for (int i = 0; i < chain.getNrOfSegments(); i++) {
+  // Update the left_joint with the fixed joints from the URDF. Get each of the link's properties from GetLinkProperties
+  // service and
+  // call the SetLinkProperties service with the same set of parameters except for the gravity_mode, which would be
+  // disabled. This is
+  // to disable the gravity in the links, thereby to eliminate the need for gravity compensation
+  for (int i = 0; i < chain.getNrOfSegments(); i++)
+  {
     std::string seg_name = chain.getSegment(i).getName();
     std::string joint_name = chain.getSegment(i).getJoint().getName();
     idx = std::find(info.joint_names.begin(), info.joint_names.end(), joint_name);
-    if (idx != info.joint_names.end()) {
+    if (idx != info.joint_names.end())
+    {
       left_joint.push_back(*idx);
     }
-    getlinkproperties.request.link_name=chain.getSegment(i).getName();
+    getlinkproperties.request.link_name = chain.getSegment(i).getName();
     std::string link_name = chain.getSegment(i).getName();
-    getlinkproperties.request.link_name=link_name;
-    setlinkproperties.request.link_name=link_name;
+    getlinkproperties.request.link_name = link_name;
+    setlinkproperties.request.link_name = link_name;
     get_lp_client.call(getlinkproperties);
     setlinkproperties.request.com = getlinkproperties.response.com;
     setlinkproperties.request.mass = getlinkproperties.response.mass;
@@ -161,16 +173,16 @@ bool Kinematics::init_grav() {
     set_lp_client.call(setlinkproperties);
   }
 
-  //Create a gravity solver for the left chain
-  gravity_solver_l = new KDL::ChainIdSolver_RNE(grav_chain_l,
-                                                KDL::Vector(0.0, 0.0, -9.8));
+  // Create a gravity solver for the left chain
+  gravity_solver_l = new KDL::ChainIdSolver_RNE(grav_chain_l, KDL::Vector(0.0, 0.0, -9.8));
   return true;
 }
 
 /* Initializes the solvers and the other variables required
  *  @returns true is successful
  */
-bool Kinematics::init(std::string tip, int &no_jts) {
+bool Kinematics::init(std::string tip, int& no_jts)
+{
   // Get URDF XML
   std::string urdf_xml, full_urdf_xml;
   tip_name = tip;
@@ -178,20 +190,22 @@ bool Kinematics::init(std::string tip, int &no_jts) {
   nh.searchParam(urdf_xml, full_urdf_xml);
   ROS_DEBUG_NAMED("arm_kinematics", "Reading xml file from parameter server");
   std::string result;
-  if (!nh.getParam(full_urdf_xml, result)) {
-    ROS_FATAL_NAMED("arm_kinematics", "Could not load the xml from parameter server: %s",
-              urdf_xml.c_str());
+  if (!nh.getParam(full_urdf_xml, result))
+  {
+    ROS_FATAL_NAMED("arm_kinematics", "Could not load the xml from parameter server: %s", urdf_xml.c_str());
     return false;
   }
 
   // Get Root and Tip From Parameter Service
-  if (!nh.getParam("root_name", root_name)) {
+  if (!nh.getParam("root_name", root_name))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "GenericIK: No root name found on parameter server");
     return false;
   }
 
   // Load and Read Models
-  if (!loadModel(result)) {
+  if (!loadModel(result))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "Could not load models!");
     return false;
   }
@@ -199,7 +213,7 @@ bool Kinematics::init(std::string tip, int &no_jts) {
   // Get Solver Parameters
   int maxIterations;
   double epsilon;
-  //KDL::Vector grav;
+  // KDL::Vector grav;
 
   nh_private.param("maxIterations", maxIterations, 1000);
   nh_private.param("epsilon", epsilon, 1e-2);
@@ -207,32 +221,37 @@ bool Kinematics::init(std::string tip, int &no_jts) {
   // Build Solvers
   fk_solver = new KDL::ChainFkSolverPos_recursive(chain);
   ik_solver_vel = new KDL::ChainIkSolverVel_pinv(chain);
-  ik_solver_pos = new KDL::ChainIkSolverPos_NR_JL(chain, joint_min, joint_max,
-                                                  *fk_solver, *ik_solver_vel,
-                                                  maxIterations, epsilon);
-  no_jts=num_joints;
+  ik_solver_pos =
+      new KDL::ChainIkSolverPos_NR_JL(chain, joint_min, joint_max, *fk_solver, *ik_solver_vel, maxIterations, epsilon);
+  no_jts = num_joints;
   return true;
 }
 
 /* Method to load all the values from the parameter server
  *  @returns true is successful
  */
-bool Kinematics::loadModel(const std::string xml) {
+bool Kinematics::loadModel(const std::string xml)
+{
   urdf::Model robot_model;
   KDL::Tree tree;
-  if (!robot_model.initString(xml)) {
+  if (!robot_model.initString(xml))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "Could not initialize robot model");
     return -1;
   }
-  if (!kdl_parser::treeFromString(xml, tree)) {
+  if (!kdl_parser::treeFromString(xml, tree))
+  {
     ROS_ERROR_NAMED("arm_kinematics", "Could not initialize tree object");
     return false;
   }
-  if (!tree.getChain(root_name, tip_name, chain)) {
-    ROS_ERROR_NAMED("arm_kinematics", "Could not initialize chain object for root_name %s and tip_name %s",root_name.c_str(), tip_name.c_str());
+  if (!tree.getChain(root_name, tip_name, chain))
+  {
+    ROS_ERROR_NAMED("arm_kinematics", "Could not initialize chain object for root_name %s and tip_name %s",
+                    root_name.c_str(), tip_name.c_str());
     return false;
   }
-  if (!readJoints(robot_model)) {
+  if (!readJoints(robot_model))
+  {
     ROS_FATAL_NAMED("arm_kinematics", "Could not read information about the joints");
     return false;
   }
@@ -243,22 +262,26 @@ bool Kinematics::loadModel(const std::string xml) {
 /* Method to read the URDF model and extract the joints
  *  @returns true is successful
  */
-bool Kinematics::readJoints(urdf::Model &robot_model) {
+bool Kinematics::readJoints(urdf::Model& robot_model)
+{
   num_joints = 0;
   boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
   boost::shared_ptr<const urdf::Joint> joint;
   for (int i = 0; i < chain.getNrOfSegments(); i++)
-    while (link && link->name != root_name) {
-      if (!(link->parent_joint)) {
+    while (link && link->name != root_name)
+    {
+      if (!(link->parent_joint))
+      {
         break;
       }
       joint = robot_model.getJoint(link->parent_joint->name);
-      if (!joint) {
+      if (!joint)
+      {
         ROS_ERROR_NAMED("arm_kinematics", "Could not find joint: %s", link->parent_joint->name.c_str());
         return false;
       }
-      if (joint->type != urdf::Joint::UNKNOWN
-          && joint->type != urdf::Joint::FIXED) {
+      if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
+      {
         ROS_DEBUG_NAMED("arm_kinematics", "adding joint: [%s]", joint->name.c_str());
         num_joints++;
       }
@@ -271,19 +294,23 @@ bool Kinematics::readJoints(urdf::Model &robot_model) {
 
   link = robot_model.getLink(tip_name);
   unsigned int i = 0;
-  while (link && i < num_joints) {
+  while (link && i < num_joints)
+  {
     joint = robot_model.getJoint(link->parent_joint->name);
-    if (joint->type != urdf::Joint::UNKNOWN
-        && joint->type != urdf::Joint::FIXED) {
+    if (joint->type != urdf::Joint::UNKNOWN && joint->type != urdf::Joint::FIXED)
+    {
       ROS_DEBUG_NAMED("arm_kinematics", "getting bounds for joint: [%s]", joint->name.c_str());
 
       float lower, upper;
       int hasLimits;
-      if (joint->type != urdf::Joint::CONTINUOUS) {
+      if (joint->type != urdf::Joint::CONTINUOUS)
+      {
         lower = joint->limits->lower;
         upper = joint->limits->upper;
         hasLimits = 1;
-      } else {
+      }
+      else
+      {
         lower = -M_PI;
         upper = M_PI;
         hasLimits = 0;
@@ -304,9 +331,10 @@ bool Kinematics::readJoints(urdf::Model &robot_model) {
 /* Method to calculate the torques required to apply at each of the joints for gravity compensation
  *  @returns true is successful
  */
-bool arm_kinematics::Kinematics::getGravityTorques(
-    const sensor_msgs::JointState joint_configuration, baxter_core_msgs::SEAJointState &left_gravity, baxter_core_msgs::SEAJointState &right_gravity, bool isEnabled) {
-
+bool arm_kinematics::Kinematics::getGravityTorques(const sensor_msgs::JointState joint_configuration,
+                                                   baxter_core_msgs::SEAJointState& left_gravity,
+                                                   baxter_core_msgs::SEAJointState& right_gravity, bool isEnabled)
+{
   bool res;
   KDL::JntArray torques_l, torques_r;
   KDL::JntArray jntPosIn_l, jntPosIn_r;
@@ -314,55 +342,60 @@ bool arm_kinematics::Kinematics::getGravityTorques(
   right_gravity.name = right_joint;
   left_gravity.gravity_model_effort.resize(num_joints);
   right_gravity.gravity_model_effort.resize(num_joints);
-  if (isEnabled) {
+  if (isEnabled)
+  {
     torques_l.resize(num_joints);
     torques_r.resize(num_joints);
     jntPosIn_l.resize(num_joints);
     jntPosIn_r.resize(num_joints);
 
     // Copying the positions of the joints relative to its index in the KDL chain
-    for (unsigned int j = 0; j < joint_configuration.name.size(); j++) {
-      for (unsigned int i = 0; i < num_joints; i++) {
-        if (joint_configuration.name[j] == left_joint.at(i)) {
+    for (unsigned int j = 0; j < joint_configuration.name.size(); j++)
+    {
+      for (unsigned int i = 0; i < num_joints; i++)
+      {
+        if (joint_configuration.name[j] == left_joint.at(i))
+        {
           jntPosIn_l(i) = joint_configuration.position[j];
           break;
-        } else if (joint_configuration.name[j] == right_joint.at(i)) {
+        }
+        else if (joint_configuration.name[j] == right_joint.at(i))
+        {
           jntPosIn_r(i) = joint_configuration.position[j];
           break;
         }
       }
     }
     KDL::JntArray jntArrayNull(num_joints);
-    KDL::Wrenches wrenchNull_l(grav_chain_l.getNrOfSegments(),
-                               KDL::Wrench::Zero());
-    int code_l = gravity_solver_l->CartToJnt(jntPosIn_l, jntArrayNull,
-                                             jntArrayNull, wrenchNull_l,
-                                             torques_l);
-    KDL::Wrenches wrenchNull_r(grav_chain_r.getNrOfSegments(),
-                               KDL::Wrench::Zero());
-    int code_r = gravity_solver_r->CartToJnt(jntPosIn_r, jntArrayNull,
-                                             jntArrayNull, wrenchNull_r,
-                                             torques_r);
+    KDL::Wrenches wrenchNull_l(grav_chain_l.getNrOfSegments(), KDL::Wrench::Zero());
+    int code_l = gravity_solver_l->CartToJnt(jntPosIn_l, jntArrayNull, jntArrayNull, wrenchNull_l, torques_l);
+    KDL::Wrenches wrenchNull_r(grav_chain_r.getNrOfSegments(), KDL::Wrench::Zero());
+    int code_r = gravity_solver_r->CartToJnt(jntPosIn_r, jntArrayNull, jntArrayNull, wrenchNull_r, torques_r);
 
-    //Check if the gravity was succesfully calculated by both the solvers
-    if (code_l >= 0 && code_r >= 0) {
-
-	for (unsigned int i = 0; i < num_joints; i++) {
-            left_gravity.gravity_model_effort[i] = torques_l(i);
-            right_gravity.gravity_model_effort[i] = torques_r(i);
+    // Check if the gravity was succesfully calculated by both the solvers
+    if (code_l >= 0 && code_r >= 0)
+    {
+      for (unsigned int i = 0; i < num_joints; i++)
+      {
+        left_gravity.gravity_model_effort[i] = torques_l(i);
+        right_gravity.gravity_model_effort[i] = torques_r(i);
       }
       return true;
-    } else {
-      ROS_ERROR_THROTTLE_NAMED(
-          1.0, "arm_kinematics",
-          "KT: Failed to compute gravity torques from KDL return code for left and right arms %d %d",
-          code_l, code_r);
+    }
+    else
+    {
+      ROS_ERROR_THROTTLE_NAMED(1.0, "arm_kinematics", "KT: Failed to compute gravity torques from KDL return code for "
+                                                      "left and right arms %d %d",
+                               code_l, code_r);
       return false;
     }
-  } else {
-    for (unsigned int i = 0; i <  num_joints; i++) {
-        left_gravity.gravity_model_effort[i]=0;
-        right_gravity.gravity_model_effort[i]=0;
+  }
+  else
+  {
+    for (unsigned int i = 0; i < num_joints; i++)
+    {
+      left_gravity.gravity_model_effort[i] = 0;
+      right_gravity.gravity_model_effort[i] = 0;
     }
   }
   return true;
@@ -371,8 +404,10 @@ bool arm_kinematics::Kinematics::getGravityTorques(
 /* Method to calculate the Joint index of a particular joint from the KDL chain
  *  @returns the index of the joint
  */
-int Kinematics::getJointIndex(const std::string &name) {
-  for (unsigned int i = 0; i < info.joint_names.size(); i++) {
+int Kinematics::getJointIndex(const std::string& name)
+{
+  for (unsigned int i = 0; i < info.joint_names.size(); i++)
+  {
     if (info.joint_names[i] == name)
       return i;
   }
@@ -382,10 +417,13 @@ int Kinematics::getJointIndex(const std::string &name) {
 /* Method to calculate the KDL segment index of a particular segment from the KDL chain
  *  @returns the index of the segment
  */
-int Kinematics::getKDLSegmentIndex(const std::string &name) {
+int Kinematics::getKDLSegmentIndex(const std::string& name)
+{
   int i = 0;
-  while (i < (int) chain.getNrOfSegments()) {
-    if (chain.getSegment(i).getJoint().getName() == name) {
+  while (i < (int)chain.getNrOfSegments())
+  {
+    if (chain.getSegment(i).getJoint().getName() == name)
+    {
       return i + 1;
     }
     i++;
@@ -396,34 +434,40 @@ int Kinematics::getKDLSegmentIndex(const std::string &name) {
 /* Method to calculate the IK for the required end pose
  *  @returns true if successful
  */
-bool arm_kinematics::Kinematics::getPositionIK(
-    const geometry_msgs::PoseStamped &pose_stamp,
-    const sensor_msgs::JointState &seed, sensor_msgs::JointState *result) {
-
+bool arm_kinematics::Kinematics::getPositionIK(const geometry_msgs::PoseStamped& pose_stamp,
+                                               const sensor_msgs::JointState& seed, sensor_msgs::JointState* result)
+{
   geometry_msgs::PoseStamped pose_msg_in = pose_stamp;
   tf::Stamped<tf::Pose> transform;
   tf::Stamped<tf::Pose> transform_root;
   tf::poseStampedMsgToTF(pose_msg_in, transform);
 
-  //Do the IK
+  // Do the IK
   KDL::JntArray jnt_pos_in;
   KDL::JntArray jnt_pos_out;
 
   jnt_pos_in.resize(num_joints);
   // Copying the positions of the joints relative to its index in the KDL chain
-  for (unsigned int i = 0; i < num_joints; i++) {
+  for (unsigned int i = 0; i < num_joints; i++)
+  {
     int tmp_index = getJointIndex(seed.name[i]);
-    if (tmp_index >= 0) {
+    if (tmp_index >= 0)
+    {
       jnt_pos_in(tmp_index) = seed.position[i];
-    } else {
+    }
+    else
+    {
       ROS_ERROR_NAMED("arm_kinematics", "i: %d, No joint index for %s", i, seed.name[i].c_str());
     }
   }
 
-  //Convert F to our root_frame
-  try {
+  // Convert F to our root_frame
+  try
+  {
     tf_listener.transformPose(root_name, transform, transform_root);
-  } catch (...) {
+  }
+  catch (...)
+  {
     ROS_ERROR_NAMED("arm_kinematics", "Could not transform IK pose to frame: %s", root_name.c_str());
     return false;
   }
@@ -433,16 +477,19 @@ bool arm_kinematics::Kinematics::getPositionIK(
 
   int ik_valid = ik_solver_pos->CartToJnt(jnt_pos_in, F_dest, jnt_pos_out);
 
-  if (ik_valid >= 0) {
+  if (ik_valid >= 0)
+  {
     result->name = info.joint_names;
     result->position.resize(num_joints);
-    for (unsigned int i = 0; i < num_joints; i++) {
+    for (unsigned int i = 0; i < num_joints; i++)
+    {
       result->position[i] = jnt_pos_out(i);
-      ROS_DEBUG_NAMED("arm_kinematics", "IK Solution: %s %d: %f", result->name[i].c_str(), i,
-                jnt_pos_out(i));
+      ROS_DEBUG_NAMED("arm_kinematics", "IK Solution: %s %d: %f", result->name[i].c_str(), i, jnt_pos_out(i));
     }
     return true;
-  } else {
+  }
+  else
+  {
     ROS_DEBUG_NAMED("arm_kinematics", "An IK solution could not be found");
     return false;
   }
@@ -451,16 +498,17 @@ bool arm_kinematics::Kinematics::getPositionIK(
 /* Method to calculate the FK for the required joint configuration
  *  @returns true if successful
  */
-bool arm_kinematics::Kinematics::getPositionFK(
-    std::string frame_id, const sensor_msgs::JointState &joint_configuration,
-    geometry_msgs::PoseStamped &result) {
+bool arm_kinematics::Kinematics::getPositionFK(std::string frame_id, const sensor_msgs::JointState& joint_configuration,
+                                               geometry_msgs::PoseStamped& result)
+{
   KDL::Frame p_out;
   KDL::JntArray jnt_pos_in;
   tf::Stamped<tf::Pose> tf_pose;
 
   // Copying the positions of the joints relative to its index in the KDL chain
   jnt_pos_in.resize(num_joints);
-  for (unsigned int i = 0; i < num_joints; i++) {
+  for (unsigned int i = 0; i < num_joints; i++)
+  {
     int tmp_index = getJointIndex(joint_configuration.name[i]);
     if (tmp_index >= 0)
       jnt_pos_in(tmp_index) = joint_configuration.position[i];
@@ -468,22 +516,28 @@ bool arm_kinematics::Kinematics::getPositionFK(
 
   int num_segments = chain.getNrOfSegments();
   ROS_DEBUG_ONCE_NAMED("arm_kinematics", "Number of Segments in the KDL chain: %d", num_segments);
-  if (fk_solver->JntToCart(jnt_pos_in, p_out, num_segments) >= 0) {
+  if (fk_solver->JntToCart(jnt_pos_in, p_out, num_segments) >= 0)
+  {
     tf_pose.frame_id_ = root_name;
     tf_pose.stamp_ = ros::Time();
     tf::poseKDLToTF(p_out, tf_pose);
-    try {
+    try
+    {
       tf_listener.transformPose(frame_id, tf_pose, tf_pose);
-    } catch (...) {
+    }
+    catch (...)
+    {
       ROS_ERROR_NAMED("arm_kinematics", "Could not transform FK pose to frame: %s", frame_id.c_str());
       return false;
     }
     tf::poseStampedTFToMsg(tf_pose, result);
-  } else {
+  }
+  else
+  {
     ROS_ERROR_NAMED("arm_kinematics", "Could not compute FK for endpoint.");
     return false;
   }
   return true;
 }
 
-}  //namespace
+}  // namespace

--- a/baxter_sim_kinematics/src/position_kinematics.cpp
+++ b/baxter_sim_kinematics/src/position_kinematics.cpp
@@ -35,63 +35,66 @@
 #include <baxter_sim_kinematics/position_kinematics.h>
 #include <signal.h>
 
-namespace kinematics {
-
+namespace kinematics
+{
 static const std::string ref_frame_id = "base";
 static const std::string JOINT_STATES = "/robot/joint_states";
 static const std::string ROBOT_STATE = "/robot/state";
-const int joint_id=6;//Modify this to get the FK of different joints
+const int joint_id = 6;  // Modify this to get the FK of different joints
 
 /**
  * Method to initialize the publishing and subscribing topics, services and to acquire the resources required
  * @return true if succeeds.
  */
-bool position_kinematics::init(std::string side) {
-  //Robot would be disabled initially
+bool position_kinematics::init(std::string side)
+{
+  // Robot would be disabled initially
   is_enabled = false;
 
   // capture the side we are working on
   m_limbName = side;
 
-  //setup handle for the topics
-  std::string node_path = "/ExternalTools/" + m_limbName
-      + "/PositionKinematicsNode";
+  // setup handle for the topics
+  std::string node_path = "/ExternalTools/" + m_limbName + "/PositionKinematicsNode";
   ros::NodeHandle handle1(node_path);
 
   static const std::string LIMB_ENDPOINT = "/robot/limb/" + side + "/endpoint_state";
 
-  //setup the service server for the Inverse Kinematics
-  m_ikService = handle1.advertiseService("IKService",
-                                         &position_kinematics::IKCallback,
-                                         this);
+  // setup the service server for the Inverse Kinematics
+  m_ikService = handle1.advertiseService("IKService", &position_kinematics::IKCallback, this);
 
-  //Subscribe and advertise the subscribers and publishers accordingly for the Forward Kinematics
-  joint_states_sub = handle.subscribe < sensor_msgs::JointState
-      > (JOINT_STATES, 100, &position_kinematics::FKCallback, this);
-  end_pointstate_pub = handle.advertise < baxter_core_msgs::EndpointState
-      > (LIMB_ENDPOINT, 100);
+  // Subscribe and advertise the subscribers and publishers accordingly for the Forward Kinematics
+  joint_states_sub =
+      handle.subscribe<sensor_msgs::JointState>(JOINT_STATES, 100, &position_kinematics::FKCallback, this);
+  end_pointstate_pub = handle.advertise<baxter_core_msgs::EndpointState>(LIMB_ENDPOINT, 100);
 
-  //Subscribe to the robot state
-  robot_state_sub = handle.subscribe < baxter_core_msgs::AssemblyState
-      > (ROBOT_STATE, 100, &position_kinematics::stateCB, this);
+  // Subscribe to the robot state
+  robot_state_sub =
+      handle.subscribe<baxter_core_msgs::AssemblyState>(ROBOT_STATE, 100, &position_kinematics::stateCB, this);
 
-  //Initialize the Parameter server with the root_name and tip_name of the Kinematic Chain based on the side
-  if (side == "right") {
-    if (!handle.getParam("right_tip_name", tip_name)) {
+  // Initialize the Parameter server with the root_name and tip_name of the Kinematic Chain based on the side
+  if (side == "right")
+  {
+    if (!handle.getParam("right_tip_name", tip_name))
+    {
       ROS_FATAL("GenericIK: No tip name for Right arm found on parameter server");
       return false;
     }
-    if (!handle.getParam("robot_config/right_config/joint_names", joint_names)) {
+    if (!handle.getParam("robot_config/right_config/joint_names", joint_names))
+    {
       ROS_FATAL("GenericIK: No Joint Names for the Right Arm found on parameter server");
       return false;
     }
   }
-  else {
-    if (!handle.getParam("left_tip_name", tip_name)) {
+  else
+  {
+    if (!handle.getParam("left_tip_name", tip_name))
+    {
       ROS_FATAL("GenericIK: No tip name for Right arm found on parameter server");
       return false;
     }
-    if (!handle.getParam("robot_config/left_config/joint_names", joint_names)) {
+    if (!handle.getParam("robot_config/left_config/joint_names", joint_names))
+    {
       ROS_FATAL("GenericIK: No Joint Names for the Left Arm found on parameter server");
       return false;
     }
@@ -99,14 +102,13 @@ bool position_kinematics::init(std::string side) {
   no_jts = joint_names.size();
   m_kinematicsModel = arm_kinematics::Kinematics::create(tip_name, no_jts);
   return true;
-
 }
 
 /**
  * Callback function that checks and sets the robot enabled flag
  */
-void position_kinematics::stateCB(
-    const baxter_core_msgs::AssemblyState msg) {
+void position_kinematics::stateCB(const baxter_core_msgs::AssemblyState msg)
+{
   if (msg.enabled)
     is_enabled = true;
   else
@@ -117,34 +119,37 @@ void position_kinematics::stateCB(
  * Callback function for the FK subscriber that retrievs the appropriate FK from the Joint states and publishes
  * to the endpoint_state topic
  */
-void position_kinematics::FKCallback(const sensor_msgs::JointState msg) {
+void position_kinematics::FKCallback(const sensor_msgs::JointState msg)
+{
   baxter_core_msgs::EndpointState endpoint;
 
   sensor_msgs::JointState configuration;
 
   position_kinematics::FilterJointState(&msg, joint);
-  //Copy the current Joint positions and names of the appropriate side to the configuration
+  // Copy the current Joint positions and names of the appropriate side to the configuration
   endpoint.pose = position_kinematics::FKCalc(joint).pose;
 
-  //Fill out timestamp for endpoint
+  // Fill out timestamp for endpoint
   endpoint.header.stamp = msg.header.stamp;
 
-  //Publish the PoseStamp of the end effector
+  // Publish the PoseStamp of the end effector
   end_pointstate_pub.publish(endpoint);
 }
 
 /**
  * Method to Filter the names and positions of the initialized side from the remaining
  */
-void position_kinematics::FilterJointState(
-    const sensor_msgs::JointState *msg, sensor_msgs::JointState &res) {
+void position_kinematics::FilterJointState(const sensor_msgs::JointState* msg, sensor_msgs::JointState& res)
+{
   // Resize the result to hold the names and positions of the 7 joints
   res.name.resize(joint_names.size());
   res.position.resize(joint_names.size());
   int i = 0;
-  for (size_t ind = 0; ind < msg->name.size(); ind++) {
+  for (size_t ind = 0; ind < msg->name.size(); ind++)
+  {
     // Retain the names and positions of the joints of the initialized arm
-    if (std::find(joint_names.begin(), joint_names.end(), msg->name[ind]) != joint_names.end()) {
+    if (std::find(joint_names.begin(), joint_names.end(), msg->name[ind]) != joint_names.end())
+    {
       res.name[i] = msg->name[ind];
       res.position[i] = msg->position[ind];
       i++;
@@ -156,73 +161,78 @@ void position_kinematics::FilterJointState(
  * Method to pass the desired configuration of the joints and calculate the FK
  * @return calculated FK
  */
-geometry_msgs::PoseStamped position_kinematics::FKCalc(
-    const sensor_msgs::JointState configuration) {
+geometry_msgs::PoseStamped position_kinematics::FKCalc(const sensor_msgs::JointState configuration)
+{
   bool isV;
   geometry_msgs::PoseStamped fk_result;
-  isV = m_kinematicsModel->getPositionFK(ref_frame_id, configuration,
-                                         fk_result);
+  isV = m_kinematicsModel->getPositionFK(ref_frame_id, configuration, fk_result);
   return fk_result;
 }
 
 /**
- * Callback function for the IK service that responds with the appropriate joint configuration or error message if not found
+ * Callback function for the IK service that responds with the appropriate joint configuration or error message if not
+ * found
  */
-bool position_kinematics::IKCallback(
-    baxter_core_msgs::SolvePositionIK::Request &req,
-    baxter_core_msgs::SolvePositionIK::Response &res) {
+bool position_kinematics::IKCallback(baxter_core_msgs::SolvePositionIK::Request& req,
+                                     baxter_core_msgs::SolvePositionIK::Response& res)
+{
   ros::Rate loop_rate(100);
   sensor_msgs::JointState joint_pose;
   res.joints.resize(req.pose_stamp.size());
   res.isValid.resize(req.pose_stamp.size());
   res.result_type.resize(req.pose_stamp.size());
-  for (size_t req_index = 0; req_index < req.pose_stamp.size(); req_index++) {
+  for (size_t req_index = 0; req_index < req.pose_stamp.size(); req_index++)
+  {
+    res.isValid[req_index] = 0;
+    int valid_inp = 0;
 
-    res.isValid[req_index]=0;
-    int valid_inp=0;
-
-    if(!req.seed_angles.empty() && req.seed_mode != baxter_core_msgs::SolvePositionIKRequest::SEED_CURRENT) {
-      res.isValid[req_index] = m_kinematicsModel->getPositionIK(
-          req.pose_stamp[req_index], req.seed_angles[req_index], &joint_pose);
+    if (!req.seed_angles.empty() && req.seed_mode != baxter_core_msgs::SolvePositionIKRequest::SEED_CURRENT)
+    {
+      res.isValid[req_index] =
+          m_kinematicsModel->getPositionIK(req.pose_stamp[req_index], req.seed_angles[req_index], &joint_pose);
       res.joints[req_index].name.resize(joint_pose.name.size());
-      res.result_type[req_index]=baxter_core_msgs::SolvePositionIKRequest::SEED_USER;
-      valid_inp=1;
+      res.result_type[req_index] = baxter_core_msgs::SolvePositionIKRequest::SEED_USER;
+      valid_inp = 1;
     }
 
-    if((!res.isValid[req_index]) && req.seed_mode != baxter_core_msgs::SolvePositionIKRequest::SEED_USER) {
-      res.isValid[req_index] = m_kinematicsModel->getPositionIK(
-          req.pose_stamp[req_index], joint, &joint_pose);
+    if ((!res.isValid[req_index]) && req.seed_mode != baxter_core_msgs::SolvePositionIKRequest::SEED_USER)
+    {
+      res.isValid[req_index] = m_kinematicsModel->getPositionIK(req.pose_stamp[req_index], joint, &joint_pose);
       res.joints[req_index].name.resize(joint_pose.name.size());
-      res.result_type[req_index]=baxter_core_msgs::SolvePositionIKRequest::SEED_CURRENT;
-      valid_inp=1;
+      res.result_type[req_index] = baxter_core_msgs::SolvePositionIKRequest::SEED_CURRENT;
+      valid_inp = 1;
     }
 
-    if(!valid_inp) {
+    if (!valid_inp)
+    {
       ROS_ERROR("Not a valid request message to the IK service");
       return false;
     }
 
-    if (res.isValid[req_index]) {
+    if (res.isValid[req_index])
+    {
       res.joints[req_index].position.resize(joint_pose.position.size());
       res.joints[req_index].name = joint_pose.name;
       res.joints[req_index].position = joint_pose.position;
     }
     else
-      res.result_type[req_index]=baxter_core_msgs::SolvePositionIKResponse::RESULT_INVALID;
+      res.result_type[req_index] = baxter_core_msgs::SolvePositionIKResponse::RESULT_INVALID;
   }
   loop_rate.sleep();
 }
 
-}  //namespace
+}  // namespace
 /***************************************************************************************************/
 
 //! global pointer to Node
 kinematics::position_kinematics::poskin_ptr g_pNode;
 
 //! Helper function for
-void quitRequested(int) {
+void quitRequested(int)
+{
   ROS_INFO("position_kinematics: Terminating program...");
-  if (g_pNode) {
+  if (g_pNode)
+  {
     g_pNode->exit();
     g_pNode.reset();
   }
@@ -232,27 +242,29 @@ void quitRequested(int) {
  * Entry point for program. Sets up Node, parses
  * command line arguments, then control loop (calling run() on Node)
  */
-int main(int argc, char* argv[]) {
+int main(int argc, char* argv[])
+{
   std::string side = argc > 1 ? argv[1] : "";
-  if (side != "left" && side != "right") {
+  if (side != "left" && side != "right")
+  {
     fprintf(stderr, "Usage: %s <left | right>\n", argv[0]);
     return 1;
   }
   ros::init(argc, argv, "baxter_sim_kinematics_" + side);
 
-  //capture signals and attempt to cleanup Node
+  // capture signals and attempt to cleanup Node
   signal(SIGTERM, quitRequested);
   signal(SIGINT, quitRequested);
   signal(SIGHUP, quitRequested);
 
   g_pNode = kinematics::position_kinematics::create(side);
 
-  //test to see if pointer is valid
-  if (g_pNode) {
+  // test to see if pointer is valid
+  if (g_pNode)
+  {
     g_pNode->run();
   }
 
-  //position_kinematics calls ros::shutdown upon exit, just return here
+  // position_kinematics calls ros::shutdown upon exit, just return here
   return 0;
 }
-


### PR DESCRIPTION
Uses MoveIt's [clang-format](https://github.com/ros-planning/moveit/blob/kinetic-devel/.clang-format)

I couldn't stand working in the code base with bad indention, etc. I'm currently trying to fix https://github.com/RethinkRobotics/baxter_simulator/issues/46

*This PR is sponsored by [Vicarious](http://www.vicarious.com/)*