### PR TITLE
[baxter_gazebo] Fix build c++11 gazebo6 and upper version.

### DIFF
--- a/baxter_gazebo/CMakeLists.txt
+++ b/baxter_gazebo/CMakeLists.txt
@@ -35,6 +35,8 @@ include_directories(include
   ${GAZEBO_INCLUDE_DIRS}
 )
 
+list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
+
 add_library(baxter_gazebo_ros_control
   src/baxter_gazebo_ros_control_plugin.cpp
 )


### PR DESCRIPTION
According to the tutorials, we need to add one line below in `CMakeLists.txt` for `gazebo6` and above
```cmake
list(APPEND CMAKE_CXX_FLAGS "${GAZEBO_CXX_FLAGS}")
```

http://gazebosim.org/tutorials?tut=plugins_hello_world