### PR TITLE
Fix compilation on Ubuntu 18.04 w ROS Melodic

### DIFF
--- a/baxter_gazebo/launch/baxter_world.launch
+++ b/baxter_gazebo/launch/baxter_world.launch
@@ -19,7 +19,7 @@
              to launching baxter_world -->
   <arg name="load_robot_description" default="true"/>
   <param if="$(arg load_robot_description)" name="robot_description"
-      command="$(find xacro)/xacro.py --inorder $(find baxter_description)/urdf/baxter.urdf.xacro gazebo:=true"/>
+      command="$(find xacro)/xacro $(find baxter_description)/urdf/baxter.urdf.xacro gazebo:=true"/>
 
   <!-- We resume the logic in empty_world.launch, changing the name of the world to be launched -->
   <include file="$(find gazebo_ros)/launch/empty_world.launch">

--- a/baxter_sim_io/include/baxter_sim_io/qnode.hpp
+++ b/baxter_sim_io/include/baxter_sim_io/qnode.hpp
@@ -34,12 +34,15 @@
 #ifndef baxter_sim_io_QNODE_HPP_
 #define baxter_sim_io_QNODE_HPP_
 
+#ifndef Q_MOC_RUN
 #include <ros/ros.h>
+#include <baxter_core_msgs/NavigatorState.h>
+#include <baxter_core_msgs/DigitalIOState.h>
+#endif
+
 #include <string>
 #include <QThread>
 #include <QStringListModel>
-#include <baxter_core_msgs/NavigatorState.h>
-#include <baxter_core_msgs/DigitalIOState.h>
 
 namespace baxter_sim_io {
 

--- a/baxter_sim_kinematics/src/arm_kinematics.cpp
+++ b/baxter_sim_kinematics/src/arm_kinematics.cpp
@@ -34,6 +34,7 @@
 #include <cstring>
 #include <ros/ros.h>
 #include <baxter_sim_kinematics/arm_kinematics.h>
+#include <memory>
 
 namespace arm_kinematics {
 
@@ -245,8 +246,8 @@ bool Kinematics::loadModel(const std::string xml) {
  */
 bool Kinematics::readJoints(urdf::Model &robot_model) {
   num_joints = 0;
-  boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
-  boost::shared_ptr<const urdf::Joint> joint;
+  std::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
+  std::shared_ptr<const urdf::Joint> joint;
   for (int i = 0; i < chain.getNrOfSegments(); i++)
     while (link && link->name != root_name) {
       if (!(link->parent_joint)) {

--- a/baxter_sim_kinematics/src/arm_kinematics.cpp
+++ b/baxter_sim_kinematics/src/arm_kinematics.cpp
@@ -34,7 +34,7 @@
 #include <cstring>
 #include <ros/ros.h>
 #include <baxter_sim_kinematics/arm_kinematics.h>
-#if ROS_VERSION_MINIMUN(1, 14, 0)  //Melodic
+#if ROS_VERSION_MINIMUM(1, 14, 0)  //Melodic
 #include <memory>
 #endif
 
@@ -248,7 +248,7 @@ bool Kinematics::loadModel(const std::string xml) {
  */
 bool Kinematics::readJoints(urdf::Model &robot_model) {
   num_joints = 0;
-  #if ROS_VERSION_MINIMUN(1, 14, 0)  // Melodic
+  #if ROS_VERSION_MINIMUM(1, 14, 0)  // Melodic
   std::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
   std::shared_ptr<const urdf::Joint> joint;
   #else

--- a/baxter_sim_kinematics/src/arm_kinematics.cpp
+++ b/baxter_sim_kinematics/src/arm_kinematics.cpp
@@ -34,7 +34,9 @@
 #include <cstring>
 #include <ros/ros.h>
 #include <baxter_sim_kinematics/arm_kinematics.h>
+#if ROS_VERSION_MINIMUN(1, 14, 0)  //Melodic
 #include <memory>
+#endif
 
 namespace arm_kinematics {
 
@@ -246,8 +248,13 @@ bool Kinematics::loadModel(const std::string xml) {
  */
 bool Kinematics::readJoints(urdf::Model &robot_model) {
   num_joints = 0;
+  #if ROS_VERSION_MINIMUN(1, 14, 0)  // Melodic
   std::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
   std::shared_ptr<const urdf::Joint> joint;
+  #else
+  boost::shared_ptr<const urdf::Link> link = robot_model.getLink(tip_name);
+  boost::shared_ptr<const urdf::Joint> joint;
+  #endif
   for (int i = 0; i < chain.getNrOfSegments(); i++)
     while (link && link->name != root_name) {
       if (!(link->parent_joint)) {


### PR DESCRIPTION
On systems with qt-moc versione 5 or above, MOC generation fails. 

This patch excludes ros includes (and thus the problematic boost includes) from sources during MOC generation.
This patch also migrates to std::shared_ptr, as it seems that URDF library migrated to them, leading to build errors.